### PR TITLE
feat: add calendar export (.ics) for bookings (issue #44)

### DIFF
--- a/booking_system_backend/server.py
+++ b/booking_system_backend/server.py
@@ -1,6 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import Response
 from fastmcp import FastMCP
 from sqlalchemy.orm import Session
 from typing import Union, Optional
@@ -74,6 +75,22 @@ def cancel_booking(booking_id: int) -> BookingOut:
         return result
     finally:
         db.close()
+
+
+@mcp.tool()
+def export_booking_ics(booking_id: int) -> str:
+    """Export a booking as an iCalendar (.ics) string.
+    Returns the raw iCal text for the given booking_id, or raises an error if the booking is not found."""
+    db = SessionLocal()
+    try:
+        result = booking.generate_ics(db, booking_id)
+        if isinstance(result, ErrorResponse):
+            raise Exception(result.details or result.error)
+        return result
+    finally:
+        db.close()
+
+
 
 
 @mcp.tool()
@@ -242,6 +259,20 @@ def book_flight_endpoint(request: BookingRequest, db: Session = Depends(get_db))
     Decrements available seats for the selected class if successful.
     """
     return booking.book_flight(db, request.user_id, request.name, request.flight_id, request.seat_class)
+
+
+@app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
+def export_booking_ics_endpoint(booking_id: int, db: Session = Depends(get_db)):
+    """Export a booking as an iCalendar (.ics) file.
+
+    Returns a text/calendar response for the given booking_id.
+    Returns HTTP 404 if the booking does not exist.
+    """
+    result = booking.generate_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.error)
+    return Response(content=result, media_type="text/calendar",
+                    headers={"Content-Disposition": f"attachment; filename=booking-{booking_id}.ics"})
 
 
 @app.get("/bookings/{user_id}", response_model=list[BookingOut], tags=["Bookings"])

--- a/booking_system_backend/services/booking.py
+++ b/booking_system_backend/services/booking.py
@@ -126,3 +126,50 @@ def get_bookings(db: Session, user_id: int) -> list[BookingOut]:
     """Retrieve all bookings for a specific user."""
     bookings = db.query(Booking).filter(Booking.user_id == user_id).all()
     return [BookingOut.model_validate(b) for b in bookings]
+
+
+def generate_ics(db: Session, booking_id: int) -> str | ErrorResponse:
+    """Generate an iCalendar (.ics) string for an existing booking."""
+    booking = db.query(Booking).filter(Booking.booking_id == booking_id).first()
+    if not booking:
+        return ErrorResponse(
+            error="Booking not found",
+            error_code="BOOKING_NOT_FOUND",
+            details=f"Booking with ID {booking_id} does not exist."
+        )
+
+    flight = db.query(Flight).filter(Flight.flight_id == booking.flight_id).first()
+    origin = flight.origin if flight else "Unknown"
+    destination = flight.destination if flight else "Unknown"
+    departure = flight.departure_time if flight else ""
+    arrival = flight.arrival_time if flight else ""
+
+    def to_ical_dt(dt_str: str) -> str:
+        """Convert 'YYYY-MM-DD HH:MM' to iCal basic format YYYYMMDDTHHMMSS."""
+        try:
+            dt = datetime.strptime(dt_str, "%Y-%m-%d %H:%M")
+            return dt.strftime("%Y%m%dT%H%M%S")
+        except ValueError:
+            return dt_str.replace("-", "").replace(" ", "T").replace(":", "")
+
+    dtstart = to_ical_dt(departure)
+    dtend = to_ical_dt(arrival)
+    uid = f"booking-{booking_id}@galaxium-travels"
+    dtstamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+    ics = (
+        "BEGIN:VCALENDAR\r\n"
+        "VERSION:2.0\r\n"
+        "PRODID:-//Galaxium Travels//Booking//EN\r\n"
+        "BEGIN:VEVENT\r\n"
+        f"UID:{uid}\r\n"
+        f"DTSTAMP:{dtstamp}\r\n"
+        f"DTSTART:{dtstart}\r\n"
+        f"DTEND:{dtend}\r\n"
+        f"SUMMARY:Galaxium Travels: {origin} → {destination}\r\n"
+        f"LOCATION:{origin} to {destination}\r\n"
+        f"DESCRIPTION:Booking #{booking_id}\\nSeat class: {booking.seat_class}\\nStatus: {booking.status}\r\n"
+        "END:VEVENT\r\n"
+        "END:VCALENDAR\r\n"
+    )
+    return ics

--- a/booking_system_backend/tests/test_rest.py
+++ b/booking_system_backend/tests/test_rest.py
@@ -870,3 +870,54 @@ class TestFlightsEndpointFiltering:
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 2
+
+
+class TestIcsExportEndpoint:
+    """Test GET /bookings/{booking_id}/export.ics endpoint."""
+
+    def _create_booking(self, client, db_session, sample_user_data):
+        user_response = client.post("/register", json=sample_user_data)
+        user_id = user_response.json()["user_id"]
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-06-01 10:00",
+            arrival_time="2099-06-01 18:00",
+            base_price=1000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+        flight = db_session.query(Flight).first()
+        db_session.add(Booking(
+            user_id=user_id,
+            flight_id=flight.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000
+        ))
+        db_session.commit()
+        return db_session.query(Booking).first()
+
+    def test_export_ics_success(self, client, db_session, sample_user_data):
+        """GET /bookings/{id}/export.ics returns 200 with text/calendar content."""
+        booking_obj = self._create_booking(client, db_session, sample_user_data)
+        response = client.get(f"/bookings/{booking_obj.booking_id}/export.ics")
+
+        assert response.status_code == 200
+        assert "text/calendar" in response.headers["content-type"]
+        body = response.text
+        assert "BEGIN:VCALENDAR" in body
+        assert "BEGIN:VEVENT" in body
+        assert "SUMMARY:" in body
+        assert "DTSTART:" in body
+        assert "DTEND:" in body
+        assert "DESCRIPTION:" in body
+        assert f"UID:booking-{booking_obj.booking_id}@galaxium-travels" in body
+
+    def test_export_ics_not_found(self, client, db_session):
+        """GET /bookings/99999/export.ics returns 404."""
+        response = client.get("/bookings/99999/export.ics")
+        assert response.status_code == 404

--- a/booking_system_backend/tests/test_services.py
+++ b/booking_system_backend/tests/test_services.py
@@ -973,3 +973,57 @@ class TestFlightFiltering:
 
         results = flight.list_flights(db_session, min_price=10000000)
         assert len(results) == 0
+
+
+class TestIcsExport:
+    """Test generate_ics service function."""
+
+    def _make_booking(self, db_session):
+        db_session.add(User(name="Test User", email="ics@example.com"))
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-06-01 10:00",
+            arrival_time="2099-06-01 18:00",
+            base_price=1000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000
+        ))
+        db_session.commit()
+        return db_session.query(Booking).first()
+
+    def test_generate_ics_success(self, db_session):
+        """generate_ics returns a valid iCal string with required fields."""
+        booking_obj = self._make_booking(db_session)
+        result = booking.generate_ics(db_session, booking_obj.booking_id)
+
+        assert isinstance(result, str)
+        assert "BEGIN:VCALENDAR" in result
+        assert "BEGIN:VEVENT" in result
+        assert "SUMMARY:" in result
+        assert "LOCATION:" in result
+        assert "DTSTART:" in result
+        assert "DTEND:" in result
+        assert "DESCRIPTION:" in result
+        assert f"UID:booking-{booking_obj.booking_id}@galaxium-travels" in result
+        assert "Earth" in result
+        assert "Mars" in result
+
+    def test_generate_ics_not_found(self, db_session):
+        """generate_ics returns ErrorResponse for a missing booking."""
+        from schemas import ErrorResponse
+        result = booking.generate_ics(db_session, 99999)
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "BOOKING_NOT_FOUND"

--- a/booking_system_frontend/src/components/bookings/BookingCard.tsx
+++ b/booking_system_frontend/src/components/bookings/BookingCard.tsx
@@ -1,6 +1,6 @@
 import type { Booking, Flight } from '../../types';
 import { Card, Button } from '../common';
-import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket } from 'lucide-react';
+import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket, CalendarPlus } from 'lucide-react';
 import { formatDate, formatCurrency } from '../../utils/formatters';
 import { motion } from 'framer-motion';
 
@@ -71,6 +71,14 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
   };
 
   const canCancel = booking.status === 'booked';
+
+  const handleExportIcs = () => {
+    const url = `/api/bookings/${booking.booking_id}/export.ics`;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `booking-${booking.booking_id}.ics`;
+    a.click();
+  };
 
   return (
     <motion.div
@@ -153,17 +161,28 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
           <span>Booked on {formatDate(booking.booking_time)}</span>
         </div>
 
-        {/* Cancel Button */}
+        {/* Action Buttons */}
         {canCancel && (
-          <Button
-            variant="danger"
-            size="sm"
-            onClick={() => onCancel(booking.booking_id)}
-            isLoading={isCancelling}
-            className="w-full"
-          >
-            Cancel Booking
-          </Button>
+          <div className="flex flex-col gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleExportIcs}
+              className="w-full"
+            >
+              <CalendarPlus size={14} className="mr-1" />
+              Add to Calendar
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => onCancel(booking.booking_id)}
+              isLoading={isCancelling}
+              className="w-full"
+            >
+              Cancel Booking
+            </Button>
+          </div>
         )}
       </Card>
     </motion.div>


### PR DESCRIPTION
# Summary

Adds iCalendar (`.ics`) export functionality for bookings, allowing users to download their flight booking details directly into their calendar application. This feature is exposed via a new REST endpoint, an MCP tool, and an "Add to Calendar" button in the frontend booking card UI. Full test coverage is included for both the service layer and the REST endpoint.

# Files Changed

📄 `booking_system_backend/server.py`

- Imports `fastapi.responses.Response` to support returning raw file responses.
- Adds a new MCP tool `export_booking_ics` that wraps the `generate_ics` service function and returns the raw iCal string, raising an exception if the booking is not found.
- Adds a new REST endpoint `GET /bookings/{booking_id}/export.ics` that returns a `text/calendar` response with a `Content-Disposition` header prompting a file download, or a 404 if the booking does not exist.

📄 `booking_system_backend/services/booking.py`

- Adds the `generate_ics` service function, which queries the database for a booking and its associated flight, then constructs and returns a standards-compliant iCalendar string including `VEVENT` fields such as `DTSTART`, `DTEND`, `SUMMARY`, `LOCATION`, `DESCRIPTION`, and a unique `UID`.
- Returns an `ErrorResponse` with error code `BOOKING_NOT_FOUND` if the booking does not exist.

📄 `booking_system_backend/tests/test_rest.py`

- Adds the `TestIcsExportEndpoint` test class covering the `GET /bookings/{booking_id}/export.ics` endpoint.
- Includes a helper method `_create_booking` to set up the required user, flight, and booking fixtures.
- Tests that a valid request returns HTTP 200 with `text/calendar` content type and all expected iCal fields.
- Tests that a request for a non-existent booking returns HTTP 404.

📄 `booking_system_backend/tests/test_services.py`

- Adds the `TestIcsExport` test class covering the `generate_ics` service function directly.
- Includes a helper method `_make_booking` to create the necessary database fixtures.
- Tests that a successful call returns a valid iCal string containing all required fields and correct origin/destination values.
- Tests that calling the function with a non-existent booking ID returns an `ErrorResponse` with the `BOOKING_NOT_FOUND` error code.

📄 `booking_system_frontend/src/components/bookings/BookingCard.tsx`

- Imports the `CalendarPlus` icon from `lucide-react`.
- Adds a `handleExportIcs` function that programmatically triggers a file download by navigating to the `/api/bookings/{booking_id}/export.ics` endpoint via a dynamically created anchor element.
- Restructures the action button section to display both a new "Add to Calendar" button (using the `secondary` variant) and the existing "Cancel Booking" button stacked vertically when the booking is in a cancellable state.