### PR TITLE
feat: add calendar export (.ics) for bookings (issue #44)

### DIFF
--- a/booking_system_backend/server.py
+++ b/booking_system_backend/server.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.responses import Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastmcp import FastMCP
 from sqlalchemy.orm import Session
@@ -69,6 +70,20 @@ def cancel_booking(booking_id: int) -> BookingOut:
     db = SessionLocal()
     try:
         result = booking.cancel_booking(db, booking_id)
+        if isinstance(result, ErrorResponse):
+            raise Exception(result.details or result.error)
+        return result
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def export_booking_ics(booking_id: int) -> str:
+    """Export a booking as an iCalendar (.ics) file string.
+    Returns the raw iCal text for the booking's flight event, or raises an error if not found."""
+    db = SessionLocal()
+    try:
+        result = booking.generate_ics(db, booking_id)
         if isinstance(result, ErrorResponse):
             raise Exception(result.details or result.error)
         return result
@@ -242,6 +257,23 @@ def book_flight_endpoint(request: BookingRequest, db: Session = Depends(get_db))
     Decrements available seats for the selected class if successful.
     """
     return booking.book_flight(db, request.user_id, request.name, request.flight_id, request.seat_class)
+
+
+@app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
+def export_booking_ics_endpoint(booking_id: int, db: Session = Depends(get_db)):
+    """Export a booking as an iCalendar (.ics) file.
+
+    Returns a text/calendar response that triggers a calendar file download.
+    Returns HTTP 404 if the booking is not found.
+    """
+    result = booking.generate_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.error)
+    return Response(
+        content=result,
+        media_type="text/calendar",
+        headers={"Content-Disposition": f"attachment; filename=booking-{booking_id}.ics"}
+    )
 
 
 @app.get("/bookings/{user_id}", response_model=list[BookingOut], tags=["Bookings"])

--- a/booking_system_backend/services/booking.py
+++ b/booking_system_backend/services/booking.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import Session
-from datetime import datetime
+from datetime import datetime, timezone
 from models import User, Flight, Booking
 from schemas import BookingOut, ErrorResponse, SeatClass
 
@@ -126,3 +126,59 @@ def get_bookings(db: Session, user_id: int) -> list[BookingOut]:
     """Retrieve all bookings for a specific user."""
     bookings = db.query(Booking).filter(Booking.user_id == user_id).all()
     return [BookingOut.model_validate(b) for b in bookings]
+
+
+def generate_ics(db: Session, booking_id: int) -> str | ErrorResponse:
+    """Generate an iCalendar (.ics) string for a booking's flight event."""
+    booking = db.query(Booking).filter(Booking.booking_id == booking_id).first()
+    if not booking:
+        return ErrorResponse(
+            error="Booking not found",
+            error_code="BOOKING_NOT_FOUND",
+            details=f"Booking with ID {booking_id} not found."
+        )
+
+    flight = db.query(Flight).filter(Flight.flight_id == booking.flight_id).first()
+
+    # Format datetimes as iCal basic format: YYYYMMDDTHHmmssZ
+    def to_ical_dt(dt_str: str) -> str:
+        dt = datetime.fromisoformat(dt_str.replace(" ", "T"))
+        return dt.strftime("%Y%m%dT%H%M%SZ")
+
+    now_stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    uid = f"galaxium-booking-{booking_id}@galaxium-travels"
+
+    if flight:
+        dtstart = to_ical_dt(flight.departure_time)
+        dtend = to_ical_dt(flight.arrival_time)
+        summary = f"Galaxium Flight: {flight.origin} → {flight.destination}"
+        location = f"{flight.origin} to {flight.destination}"
+        description = (
+            f"Booking #{booking_id}\\n"
+            f"Flight #{flight.flight_id}\\n"
+            f"Seat Class: {booking.seat_class.capitalize()}\\n"
+            f"Price Paid: {booking.price_paid} credits"
+        )
+    else:
+        dtstart = now_stamp
+        dtend = now_stamp
+        summary = f"Galaxium Booking #{booking_id}"
+        location = ""
+        description = f"Booking #{booking_id}\\nFlight #{booking.flight_id}"
+
+    ics = (
+        "BEGIN:VCALENDAR\r\n"
+        "VERSION:2.0\r\n"
+        "PRODID:-//Galaxium Travels//Booking Export//EN\r\n"
+        "BEGIN:VEVENT\r\n"
+        f"UID:{uid}\r\n"
+        f"DTSTAMP:{now_stamp}\r\n"
+        f"DTSTART:{dtstart}\r\n"
+        f"DTEND:{dtend}\r\n"
+        f"SUMMARY:{summary}\r\n"
+        f"LOCATION:{location}\r\n"
+        f"DESCRIPTION:{description}\r\n"
+        "END:VEVENT\r\n"
+        "END:VCALENDAR\r\n"
+    )
+    return ics

--- a/booking_system_backend/tests/test_rest.py
+++ b/booking_system_backend/tests/test_rest.py
@@ -870,3 +870,54 @@ class TestFlightsEndpointFiltering:
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 2
+
+
+class TestIcsExportEndpoint:
+    """Test GET /bookings/{booking_id}/export.ics endpoint."""
+
+    def test_export_ics_success(self, client, db_session, sample_user_data):
+        """Test successful ICS export returns text/calendar response."""
+        user_response = client.post("/register", json=sample_user_data)
+        user_id = user_response.json()["user_id"]
+
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-06-15 09:00",
+            arrival_time="2099-06-15 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+        flight = db_session.query(Flight).first()
+
+        db_session.add(Booking(
+            user_id=user_id,
+            flight_id=flight.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000000
+        ))
+        db_session.commit()
+        booking_obj = db_session.query(Booking).first()
+
+        response = client.get(f"/bookings/{booking_obj.booking_id}/export.ics")
+
+        assert response.status_code == 200
+        assert "text/calendar" in response.headers["content-type"]
+        body = response.text
+        assert "BEGIN:VCALENDAR" in body
+        assert "BEGIN:VEVENT" in body
+        assert "SUMMARY:" in body
+        assert "DTSTART:" in body
+        assert "DTEND:" in body
+        assert "DESCRIPTION:" in body
+        assert "UID:" in body
+
+    def test_export_ics_not_found(self, client, db_session):
+        """Test ICS export for non-existent booking returns HTTP 404."""
+        response = client.get("/bookings/99999/export.ics")
+        assert response.status_code == 404

--- a/booking_system_backend/tests/test_services.py
+++ b/booking_system_backend/tests/test_services.py
@@ -973,3 +973,59 @@ class TestFlightFiltering:
 
         results = flight.list_flights(db_session, min_price=10000000)
         assert len(results) == 0
+
+
+class TestIcsExport:
+    """Test generate_ics service function."""
+
+    def test_generate_ics_success(self, db_session):
+        """Test successful ICS generation returns valid iCal content."""
+        db_session.add(User(name="Test User", email="test@example.com"))
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-06-15 09:00",
+            arrival_time="2099-06-15 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000000
+        ))
+        db_session.commit()
+        booking_obj = db_session.query(Booking).first()
+
+        result = booking.generate_ics(db_session, booking_obj.booking_id)
+
+        assert isinstance(result, str)
+        assert "BEGIN:VCALENDAR" in result
+        assert "END:VCALENDAR" in result
+        assert "BEGIN:VEVENT" in result
+        assert "END:VEVENT" in result
+        assert "SUMMARY:" in result
+        assert "LOCATION:" in result
+        assert "DTSTART:" in result
+        assert "DTEND:" in result
+        assert "DESCRIPTION:" in result
+        assert f"UID:galaxium-booking-{booking_obj.booking_id}@galaxium-travels" in result
+        assert "Earth" in result
+        assert "Mars" in result
+
+    def test_generate_ics_booking_not_found(self, db_session):
+        """Test ICS generation for non-existent booking returns ErrorResponse."""
+        result = booking.generate_ics(db_session, 99999)
+
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "BOOKING_NOT_FOUND"

--- a/booking_system_frontend/src/components/bookings/BookingCard.tsx
+++ b/booking_system_frontend/src/components/bookings/BookingCard.tsx
@@ -72,6 +72,21 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
 
   const canCancel = booking.status === 'booked';
 
+  const handleExportIcs = () => {
+    fetch(`/api/bookings/${booking.booking_id}/export.ics`)
+      .then((res) => res.blob())
+      .then((blob) => {
+        const objectUrl = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = objectUrl;
+        a.download = `booking-${booking.booking_id}.ics`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(objectUrl);
+      });
+  };
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -153,17 +168,28 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
           <span>Booked on {formatDate(booking.booking_time)}</span>
         </div>
 
-        {/* Cancel Button */}
+        {/* Action Buttons */}
         {canCancel && (
-          <Button
-            variant="danger"
-            size="sm"
-            onClick={() => onCancel(booking.booking_id)}
-            isLoading={isCancelling}
-            className="w-full"
-          >
-            Cancel Booking
-          </Button>
+          <div className="flex flex-col gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleExportIcs}
+              className="w-full"
+            >
+              <Calendar size={14} className="mr-1" />
+              Add to Calendar
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => onCancel(booking.booking_id)}
+              isLoading={isCancelling}
+              className="w-full"
+            >
+              Cancel Booking
+            </Button>
+          </div>
         )}
       </Card>
     </motion.div>


### PR DESCRIPTION
# Summary

Adds iCalendar (`.ics`) export functionality for bookings, allowing users to download a calendar file for their flight and add it to their calendar application. This feature is exposed via a new REST API endpoint, an MCP tool, and a frontend "Add to Calendar" button on each booking card. Accompanying service logic and tests are also included.

# Files Changed

📄 `booking_system_backend/server.py`

Adds two new entries to the server:
- An MCP tool `export_booking_ics` that calls the new `generate_ics` service function and returns the raw iCal string, raising an exception if the booking is not found.
- A REST endpoint `GET /bookings/{booking_id}/export.ics` that returns a `text/calendar` response with a `Content-Disposition` header to trigger a file download, or HTTP 404 if the booking does not exist. Also imports `Response` from `fastapi.responses` to support the new endpoint.

📄 `booking_system_backend/services/booking.py`

Adds the `generate_ics` service function that generates a standards-compliant iCalendar (`.ics`) string for a given booking. It queries the booking and its associated flight, formats the departure/arrival datetimes into iCal format, and constructs a `VCALENDAR`/`VEVENT` block with fields including `UID`, `DTSTAMP`, `DTSTART`, `DTEND`, `SUMMARY`, `LOCATION`, and `DESCRIPTION`. Returns an `ErrorResponse` if the booking is not found. Also updates the `datetime` import to include `timezone` for UTC timestamping.

📄 `booking_system_backend/tests/test_rest.py`

Adds the `TestIcsExportEndpoint` test class with two test cases for the new REST endpoint:
- `test_export_ics_success`: Creates a user, flight, and booking, then asserts the endpoint returns HTTP 200 with a `text/calendar` content type and a valid iCal body containing the expected fields.
- `test_export_ics_not_found`: Asserts the endpoint returns HTTP 404 for a non-existent booking ID.

📄 `booking_system_backend/tests/test_services.py`

Adds the `TestIcsExport` test class with two test cases for the `generate_ics` service function:
- `test_generate_ics_success`: Creates a user, flight, and booking, then asserts the returned string is valid iCal content containing all required fields and the correct flight origin/destination.
- `test_generate_ics_booking_not_found`: Asserts that querying a non-existent booking ID returns an `ErrorResponse` with the `BOOKING_NOT_FOUND` error code.

📄 `booking_system_frontend/src/components/bookings/BookingCard.tsx`

Updates the `BookingCard` component to add an "Add to Calendar" button alongside the existing "Cancel Booking" button for active bookings. The new `handleExportIcs` handler fetches the `.ics` file from the API, creates a temporary object URL, and programmatically triggers a file download. The two action buttons are wrapped in a flex column container, and a `Calendar` icon is added to the new button for visual clarity.