### PR TITLE
feat: add iCal export for bookings and update booking card UI

### DIFF
--- a/.bob/custom_modes.yaml
+++ b/.bob/custom_modes.yaml
@@ -1,47 +1,47 @@
-# customModes:
-#   - slug: code-reviewer
-#     name: Code Reviewer
-#     roleDefinition: >-
-#       You are a strict, read-only code reviewer. Your job is to read code and
-#       provide clear, actionable feedback on quality: naming conventions, code
-#       structure, consistency with project style, obvious bugs, dead code, and
-#       anything that would make the code harder to maintain or understand.
+customModes:
+  - slug: code-reviewer
+    name: Code Reviewer
+    roleDefinition: >-
+      You are a strict, read-only code reviewer. Your job is to read code and
+      provide clear, actionable feedback on quality: naming conventions, code
+      structure, consistency with project style, obvious bugs, dead code, and
+      anything that would make the code harder to maintain or understand.
 
-#       You never edit or create files. You never run the application. You may run
-#       linters and test suites to gather evidence, but only to inform your review.
+      You never edit or create files. You never run the application. You may run
+      linters and test suites to gather evidence, but only to inform your review.
 
-#       Your output is always a structured review: a short summary of findings,
-#       followed by specific issues with file references and line numbers where
-#       relevant. Distinguish between blocking issues (must fix) and suggestions
-#       (nice to have). Be direct and precise - do not pad feedback with praise.
-#     whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
-#     description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#   - slug: deploy-engineer
-#     name: Deploy Engineer
-#     roleDefinition: >-
-#       You are a Deploy Engineer. Your sole responsibility is making sure this
-#       project deploys correctly and reliably. You are an expert in the deployment
-#       scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
-#       infrastructure-as-code in this project.
+      Your output is always a structured review: a short summary of findings,
+      followed by specific issues with file references and line numbers where
+      relevant. Distinguish between blocking issues (must fix) and suggestions
+      (nice to have). Be direct and precise - do not pad feedback with praise.
+    whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
+    description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
+    groups:
+      - read
+      - execute
+      - skill
+  - slug: deploy-engineer
+    name: Deploy Engineer
+    roleDefinition: >-
+      You are a Deploy Engineer. Your sole responsibility is making sure this
+      project deploys correctly and reliably. You are an expert in the deployment
+      scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
+      infrastructure-as-code in this project.
 
-#       You only read and edit files inside the scripts/ directory. You do not
-#       touch application source code, frontend assets, or test files. If a
-#       deployment problem traces back to application code, you report it clearly
-#       but do not fix it yourself.
+      You only read and edit files inside the scripts/ directory. You do not
+      touch application source code, frontend assets, or test files. If a
+      deployment problem traces back to application code, you report it clearly
+      but do not fix it yourself.
 
-#       When reviewing or editing deploy scripts, you check for: missing error
-#       handling, hardcoded secrets or environment assumptions, non-idempotent
-#       operations, missing health checks, and steps that could cause downtime.
-#       You run commands to validate and test deploy scripts where possible.
-#     whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
-#     description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#       - - edit
-#         - fileRegex: "scripts/.*"
+      When reviewing or editing deploy scripts, you check for: missing error
+      handling, hardcoded secrets or environment assumptions, non-idempotent
+      operations, missing health checks, and steps that could cause downtime.
+      You run commands to validate and test deploy scripts where possible.
+    whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
+    description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
+    groups:
+      - read
+      - execute
+      - skill
+      - - edit
+        - fileRegex: "scripts/.*"

--- a/booking_system_backend/server.py
+++ b/booking_system_backend/server.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastmcp import FastMCP
 from sqlalchemy.orm import Session
@@ -97,6 +97,20 @@ def get_user_id(name: str, email: str) -> UserOut:
     db = SessionLocal()
     try:
         result = user.get_user(db, name, email)
+        if isinstance(result, ErrorResponse):
+            raise Exception(result.details or result.error)
+        return result
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def get_booking_ics(booking_id: int) -> str:
+    """Export a booking as an iCalendar (.ics) string.
+    Returns the iCal content for the specified booking_id, or raises an error if not found."""
+    db = SessionLocal()
+    try:
+        result = booking.get_booking_ics(db, booking_id)
         if isinstance(result, ErrorResponse):
             raise Exception(result.details or result.error)
         return result
@@ -248,6 +262,19 @@ def book_flight_endpoint(request: BookingRequest, db: Session = Depends(get_db))
 def get_user_bookings(user_id: int, db: Session = Depends(get_db)):
     """Retrieve all bookings for a specific user by user_id."""
     return booking.get_bookings(db, user_id)
+
+
+@app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
+def export_booking_ics(booking_id: int, db: Session = Depends(get_db)):
+    """Export a booking as an iCalendar (.ics) file for use with calendar applications."""
+    result = booking.get_booking_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.model_dump())
+    return Response(
+        content=result,
+        media_type="text/calendar",
+        headers={"Content-Disposition": f"attachment; filename=booking-{booking_id}.ics"},
+    )
 
 
 @app.post("/cancel/{booking_id}", response_model=Union[BookingOut, ErrorResponse], tags=["Bookings"])

--- a/booking_system_backend/services/booking.py
+++ b/booking_system_backend/services/booking.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 from datetime import datetime
 from models import User, Flight, Booking
 from schemas import BookingOut, ErrorResponse, SeatClass
+import uuid
 
 
 # Price multipliers for each seat class
@@ -126,3 +127,60 @@ def get_bookings(db: Session, user_id: int) -> list[BookingOut]:
     """Retrieve all bookings for a specific user."""
     bookings = db.query(Booking).filter(Booking.user_id == user_id).all()
     return [BookingOut.model_validate(b) for b in bookings]
+
+
+def get_booking_ics(db: Session, booking_id: int) -> str | ErrorResponse:
+    """Return an iCalendar (.ics) string for a booking.
+
+    Note: long DESCRIPTION lines may exceed the RFC 5545 75-octet folding limit;
+    this is acceptable for demo use.
+    """
+    booking = db.query(Booking).filter(Booking.booking_id == booking_id).first()
+    if not booking:
+        return ErrorResponse(
+            error="Booking not found",
+            error_code="BOOKING_NOT_FOUND",
+            details=f"Booking with ID {booking_id} not found."
+        )
+
+    flight = db.query(Flight).filter(Flight.flight_id == booking.flight_id).first()
+    if not flight:
+        return ErrorResponse(
+            error="Flight not found",
+            error_code="FLIGHT_NOT_FOUND",
+            details=f"Flight for booking {booking_id} not found."
+        )
+
+    def _to_ics_dt(dt_str: str) -> str:
+        """Normalise a datetime string (space-separated or ISO-8601) to iCal format."""
+        normalised = dt_str.replace("Z", "").replace("+00:00", "").replace(" ", "T")
+        dt = datetime.fromisoformat(normalised)
+        return dt.strftime("%Y%m%dT%H%M%SZ")
+
+    dtstart = _to_ics_dt(flight.departure_time)
+    dtend = _to_ics_dt(flight.arrival_time)
+    dtstamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    uid = str(uuid.uuid4())
+    description = (
+        f"Booking #{booking.booking_id} | "
+        f"Seat class: {booking.seat_class} | "
+        f"Price paid: {booking.price_paid} | "
+        f"Flight #{booking.flight_id}"
+    )
+    summary = f"Galaxium Flight: {flight.origin} → {flight.destination}"
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Galaxium Travels//Booking Export//EN",
+        "BEGIN:VEVENT",
+        f"UID:{uid}",
+        f"DTSTAMP:{dtstamp}",
+        f"DTSTART:{dtstart}",
+        f"DTEND:{dtend}",
+        f"SUMMARY:{summary}",
+        f"DESCRIPTION:{description}",
+        "END:VEVENT",
+        "END:VCALENDAR",
+    ]
+    return "\r\n".join(lines) + "\r\n"

--- a/booking_system_backend/tests/test_rest.py
+++ b/booking_system_backend/tests/test_rest.py
@@ -870,3 +870,49 @@ class TestFlightsEndpointFiltering:
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 2
+
+
+class TestIcsEndpoint:
+    """Test GET /bookings/{booking_id}/export.ics endpoint."""
+
+    def _seed(self, client, db_session):
+        user_response = client.post("/register", json={"name": "Test User", "email": "ics@example.com"})
+        user_id = user_response.json()["user_id"]
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-01-01 09:00",
+            arrival_time="2099-01-01 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+        flight = db_session.query(Flight).first()
+        db_session.add(Booking(
+            user_id=user_id,
+            flight_id=flight.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000000
+        ))
+        db_session.commit()
+        return db_session.query(Booking).first()
+
+    def test_export_ics_success(self, client, db_session):
+        """Export endpoint returns text/calendar content for a valid booking."""
+        booking_obj = self._seed(client, db_session)
+        response = client.get(f"/bookings/{booking_obj.booking_id}/export.ics")
+        assert response.status_code == 200
+        assert "text/calendar" in response.headers["content-type"]
+        body = response.text
+        assert "BEGIN:VCALENDAR" in body
+        assert "DTSTART:20990101T090000Z" in body
+        assert f"attachment; filename=booking-{booking_obj.booking_id}.ics" in response.headers["content-disposition"]
+
+    def test_export_ics_not_found(self, client, db_session):
+        """Export endpoint returns 404 for a non-existent booking."""
+        response = client.get("/bookings/999/export.ics")
+        assert response.status_code == 404

--- a/booking_system_backend/tests/test_services.py
+++ b/booking_system_backend/tests/test_services.py
@@ -973,3 +973,52 @@ class TestFlightFiltering:
 
         results = flight.list_flights(db_session, min_price=10000000)
         assert len(results) == 0
+
+
+class TestBookingIcsService:
+    """Test get_booking_ics service function."""
+
+    def _seed(self, db_session):
+        db_session.add(User(name="Test User", email="test@example.com"))
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-01-01 09:00",
+            arrival_time="2099-01-01 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000000
+        ))
+        db_session.commit()
+        return db_session.query(Booking).first()
+
+    def test_ics_success(self, db_session):
+        """get_booking_ics returns a valid iCal string for an existing booking."""
+        booking_obj = self._seed(db_session)
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+        assert isinstance(result, str)
+        assert "BEGIN:VCALENDAR" in result
+        assert "BEGIN:VEVENT" in result
+        assert "DTSTART:20990101T090000Z" in result
+        assert "DTEND:20990101T170000Z" in result
+        assert "Earth" in result
+        assert "Mars" in result
+        assert result.endswith("\r\n")
+
+    def test_ics_booking_not_found(self, db_session):
+        """get_booking_ics returns ErrorResponse for a non-existent booking_id."""
+        result = booking.get_booking_ics(db_session, 999)
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "BOOKING_NOT_FOUND"

--- a/booking_system_frontend/src/components/bookings/BookingCard.tsx
+++ b/booking_system_frontend/src/components/bookings/BookingCard.tsx
@@ -1,8 +1,9 @@
 import type { Booking, Flight } from '../../types';
 import { Card, Button } from '../common';
-import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket } from 'lucide-react';
+import { Plane, Calendar, CalendarPlus, CheckCircle, XCircle, Clock, Crown, Rocket } from 'lucide-react';
 import { formatDate, formatCurrency } from '../../utils/formatters';
 import { motion } from 'framer-motion';
+import { API_BASE_URL } from '../../services/api';
 
 interface BookingCardProps {
   booking: Booking;
@@ -71,6 +72,10 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
   };
 
   const canCancel = booking.status === 'booked';
+
+  const handleAddToCalendar = () => {
+    window.open(`${API_BASE_URL}/bookings/${booking.booking_id}/export.ics`, '_blank');
+  };
 
   return (
     <motion.div
@@ -153,17 +158,28 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
           <span>Booked on {formatDate(booking.booking_time)}</span>
         </div>
 
-        {/* Cancel Button */}
+        {/* Action Buttons */}
         {canCancel && (
-          <Button
-            variant="danger"
-            size="sm"
-            onClick={() => onCancel(booking.booking_id)}
-            isLoading={isCancelling}
-            className="w-full"
-          >
-            Cancel Booking
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => onCancel(booking.booking_id)}
+              isLoading={isCancelling}
+              className="flex-1"
+            >
+              Cancel Booking
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleAddToCalendar}
+              className="flex-1"
+            >
+              <CalendarPlus size={14} className="mr-1" />
+              Add to Calendar
+            </Button>
+          </div>
         )}
       </Card>
     </motion.div>

--- a/booking_system_frontend/src/services/api.ts
+++ b/booking_system_frontend/src/services/api.ts
@@ -10,9 +10,11 @@ import type {
   Hold,
 } from '../types';
 
+export const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+
 // Create axios instance with base configuration
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '/api',
+  baseURL: API_BASE_URL,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/demos/beginner-implementation-tasks/issue-44-implementation-plan-reviewed.md
+++ b/demos/beginner-implementation-tasks/issue-44-implementation-plan-reviewed.md
@@ -1,0 +1,39 @@
+# Issue #44 — Calendar Export (.ics) for Bookings
+
+**Status:** Draft · Reviewed  
+**Scope:** ~1 hour · 4 files touched · no new dependencies
+
+---
+
+## Summary
+
+The plan is solid and implementation-ready across four files: a new `get_booking_ics()` service function, a REST endpoint plus MCP tool in `server.py`, and an "Add to Calendar" button in `BookingCard.tsx`. Three concrete decisions were made during review: the two action buttons will sit 50/50 side-by-side using `flex-1`; datetime strings will be normalised via a simple `.replace()` chain before `fromisoformat()` with no defensive try/except; and the frontend download URL will reuse the `API_BASE_URL` constant already exported from `api.ts`, ensuring both dev (Vite proxy) and production routing work without any path prefix issues.
+
+---
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Button layout in `BookingCard.tsx` | 50/50 split — `flex gap-2`, each button gets `flex-1`. No `w-full` on either. Cancel = `variant="danger"`, Add to Calendar = `variant="secondary"`. Both `size="sm"`. | Cancel button is currently full-width; a side-by-side layout requires removing the width class and sharing space. 50/50 is the least-surprise choice for two equal-priority actions. |
+| Datetime normalisation strategy | Call `.replace("Z", "").replace("+00:00", "")` before `fromisoformat()`; append `Z` to the formatted `YYYYMMDDTHHMMSSZ` output. No try/except. | Conftest seeds times as `"2099-01-01 09:00"` (no Z, space-separated). Seed data and any reasonable ISO-8601 variant are handled by the strip chain. Keeping it minimal is appropriate for a demo codebase. |
+| Frontend download URL construction | Import `API_BASE_URL` from `api.ts` and construct `` `${API_BASE_URL}/bookings/{id}/export.ics` ``. | `api.ts` already resolves `VITE_API_URL \|\| '/api'`. Using the same constant ensures the Vite dev proxy forwards correctly and production works without a hardcoded path prefix. |
+
+---
+
+## Open Items
+
+- **RFC 5545 line folding:** The plan builds the iCal string manually. Long `DESCRIPTION` lines (booking ID + seat class + price + flight ID) could exceed the 75-octet RFC limit. Not a compliance blocker for demo use, but worth a note in code comments.
+- **`Response` import:** `Response` is not yet imported in `server.py`. Must be added to the `from fastapi import …` line at line 2.
+- **`CalendarPlus` icon availability:** `lucide-react` is in the project but `CalendarPlus` was not verified to exist in the pinned version. Confirm the icon name before implementation or fall back to `Calendar` (already imported in `BookingCard.tsx`).
+- **Test seeding re-use:** `test_rest.py` may not have a `seed_user_flight_booking` helper — check whether `TestIcsEndpoint` can reuse existing fixtures or needs its own seeding logic.
+
+---
+
+## Next Steps
+
+1. Add `get_booking_ics(db, booking_id) → str | ErrorResponse` to `booking_system_backend/services/booking.py`, using `.replace()` normalisation for datetimes and explicit `\r\n` line endings.
+2. Add `Response` to the `fastapi` import line in `server.py`, then add the `GET /bookings/{booking_id}/export.ics` endpoint and the matching `@mcp.tool()` — both above line 108.
+3. In `BookingCard.tsx`: import `API_BASE_URL` from `api.ts` and (verify then) import `CalendarPlus` from `lucide-react`; add `handleAddToCalendar`; wrap both buttons in `flex gap-2` with `flex-1`, removing `w-full` from Cancel.
+4. Write `TestBookingIcsService` (2 tests) in `test_services.py` and `TestIcsEndpoint` (2 tests) in `test_rest.py`.
+5. Run `cd booking_system_backend && pytest` — all tests must pass before raising a PR.


### PR DESCRIPTION
# Summary

This PR adds iCalendar (`.ics`) export functionality for bookings, allowing users to download their booking details as a calendar event. It includes a new backend service function, a REST endpoint, an MCP tool, frontend UI changes, and accompanying tests. Additionally, it introduces Bob Shell custom modes configuration, MCP server configuration, and relocates/refactors the Bob Review GitHub Actions workflow with a streamlined two-pass review prompt.

# Files Changed

📄 `.bob/custom_modes.yaml`

Adds a new Bob Shell configuration file defining two custom agent modes: `code-reviewer` (a read-only code quality auditor that can run linters and test suites but never modifies files) and `deploy-engineer` (a deployment-focused engineer scoped exclusively to the `scripts/` directory for CI/CD and infrastructure work).

📄 `.bob/mcp.json`

Introduces a new MCP server configuration file that registers two MCP servers for Bob Shell: `playwright` (via `@playwright/mcp`) for browser automation and `context7` (via `@upstash/context7-mcp`) for context retrieval.

📄 `.github/bob-review.yml` *(deleted)*

Removes the old Bob Review workflow file from the `.github/` root. It has been replaced by the correctly placed file under `.github/workflows/`.

📄 `.github/workflows/bob-review.yml`

Adds the corrected and refactored Bob Review GitHub Actions workflow (previously misplaced at `.github/bob-review.yml`). The review prompt has been significantly rewritten to use a faster two-pass approach: a quick scan of `AGENTS.md` and the diff first, followed by targeted deep-dives only when concrete red flags are found. The workflow structure (checkout, Node setup, Bob install, diff fetch, review extraction, and PR comment posting) remains largely the same.

📄 `booking_system_backend/server.py`

Adds two new endpoints/tools for iCalendar export. A new MCP tool `get_booking_ics` is registered to expose the export functionality to AI agents. A new REST endpoint `GET /bookings/{booking_id}/export.ics` is added that returns the `.ics` file as a `text/calendar` response with a `Content-Disposition` header for file download. Also imports `Response` from FastAPI to support the binary/text response type.

📄 `booking_system_backend/services/booking.py`

Implements the core `get_booking_ics` service function. It queries the database for the booking and associated flight, then constructs a valid iCalendar string (`VCALENDAR`/`VEVENT`) with fields including `DTSTART`, `DTEND`, `SUMMARY`, `DESCRIPTION`, `UID`, and `DTSTAMP`. Returns an `ErrorResponse` if the booking or flight is not found. Imports `uuid` for generating unique event identifiers.

📄 `booking_system_backend/tests/test_rest.py`

Adds a `TestIcsEndpoint` test class covering the new REST export endpoint. Includes a `_seed` helper to set up a user, flight, and booking, a success test verifying the `text/calendar` content type, iCal body content, and `Content-Disposition` header, and a 404 test for non-existent bookings.

📄 `booking_system_backend/tests/test_services.py`

Adds a `TestBookingIcsService` test class for the `get_booking_ics` service function. Includes a `_seed` helper, a success test asserting correct iCal structure and content (origin, destination, timestamps, CRLF termination), and a not-found test asserting an `ErrorResponse` with `BOOKING_NOT_FOUND` error code is returned.

📄 `booking_system_frontend/src/components/bookings/BookingCard.tsx`

Updates the `BookingCard` component to add an "Add to Calendar" button alongside the existing "Cancel Booking" button for active bookings. Imports `CalendarPlus` from `lucide-react` and `API_BASE_URL` from the API service. The `handleAddToCalendar` handler opens the `.ics` export URL in a new browser tab. The button layout is changed from a single full-width cancel button to a two-button flex row.

📄 `booking_system_frontend/src/services/api.ts`

Exports `API_BASE_URL` as a named constant so it can be reused across the frontend (specifically in `BookingCard.tsx` for constructing the `.ics` download URL) rather than being an inline anonymous value used only within the axios instance configuration.