### PR TITLE
feat: add ICS calendar export for bookings

### DIFF
--- a/.bob/custom_modes.yaml
+++ b/.bob/custom_modes.yaml
@@ -1,47 +1,47 @@
-# customModes:
-#   - slug: code-reviewer
-#     name: Code Reviewer
-#     roleDefinition: >-
-#       You are a strict, read-only code reviewer. Your job is to read code and
-#       provide clear, actionable feedback on quality: naming conventions, code
-#       structure, consistency with project style, obvious bugs, dead code, and
-#       anything that would make the code harder to maintain or understand.
+customModes:
+  - slug: code-reviewer
+    name: Code Reviewer
+    roleDefinition: >-
+      You are a strict, read-only code reviewer. Your job is to read code and
+      provide clear, actionable feedback on quality: naming conventions, code
+      structure, consistency with project style, obvious bugs, dead code, and
+      anything that would make the code harder to maintain or understand.
 
-#       You never edit or create files. You never run the application. You may run
-#       linters and test suites to gather evidence, but only to inform your review.
+      You never edit or create files. You never run the application. You may run
+      linters and test suites to gather evidence, but only to inform your review.
 
-#       Your output is always a structured review: a short summary of findings,
-#       followed by specific issues with file references and line numbers where
-#       relevant. Distinguish between blocking issues (must fix) and suggestions
-#       (nice to have). Be direct and precise - do not pad feedback with praise.
-#     whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
-#     description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#   - slug: deploy-engineer
-#     name: Deploy Engineer
-#     roleDefinition: >-
-#       You are a Deploy Engineer. Your sole responsibility is making sure this
-#       project deploys correctly and reliably. You are an expert in the deployment
-#       scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
-#       infrastructure-as-code in this project.
+      Your output is always a structured review: a short summary of findings,
+      followed by specific issues with file references and line numbers where
+      relevant. Distinguish between blocking issues (must fix) and suggestions
+      (nice to have). Be direct and precise - do not pad feedback with praise.
+    whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
+    description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
+    groups:
+      - read
+      - execute
+      - skill
+  - slug: deploy-engineer
+    name: Deploy Engineer
+    roleDefinition: >-
+      You are a Deploy Engineer. Your sole responsibility is making sure this
+      project deploys correctly and reliably. You are an expert in the deployment
+      scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
+      infrastructure-as-code in this project.
 
-#       You only read and edit files inside the scripts/ directory. You do not
-#       touch application source code, frontend assets, or test files. If a
-#       deployment problem traces back to application code, you report it clearly
-#       but do not fix it yourself.
+      You only read and edit files inside the scripts/ directory. You do not
+      touch application source code, frontend assets, or test files. If a
+      deployment problem traces back to application code, you report it clearly
+      but do not fix it yourself.
 
-#       When reviewing or editing deploy scripts, you check for: missing error
-#       handling, hardcoded secrets or environment assumptions, non-idempotent
-#       operations, missing health checks, and steps that could cause downtime.
-#       You run commands to validate and test deploy scripts where possible.
-#     whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
-#     description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#       - - edit
-#         - fileRegex: "scripts/.*"
+      When reviewing or editing deploy scripts, you check for: missing error
+      handling, hardcoded secrets or environment assumptions, non-idempotent
+      operations, missing health checks, and steps that could cause downtime.
+      You run commands to validate and test deploy scripts where possible.
+    whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
+    description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
+    groups:
+      - read
+      - execute
+      - skill
+      - - edit
+        - fileRegex: "scripts/.*"

--- a/booking_system_backend/server.py
+++ b/booking_system_backend/server.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastmcp import FastMCP
 from sqlalchemy.orm import Session
@@ -97,6 +97,21 @@ def get_user_id(name: str, email: str) -> UserOut:
     db = SessionLocal()
     try:
         result = user.get_user(db, name, email)
+        if isinstance(result, ErrorResponse):
+            raise Exception(result.details or result.error)
+        return result
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def get_booking_ics(booking_id: int) -> str:
+    """Export a booking as an iCalendar (.ics) string suitable for adding to a calendar app.
+    Returns an RFC 5545-compliant VCALENDAR string with the flight event, or raises an error
+    if the booking is not found."""
+    db = SessionLocal()
+    try:
+        result = booking.get_booking_ics(db, booking_id)
         if isinstance(result, ErrorResponse):
             raise Exception(result.details or result.error)
         return result
@@ -248,6 +263,22 @@ def book_flight_endpoint(request: BookingRequest, db: Session = Depends(get_db))
 def get_user_bookings(user_id: int, db: Session = Depends(get_db)):
     """Retrieve all bookings for a specific user by user_id."""
     return booking.get_bookings(db, user_id)
+
+
+@app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
+def export_booking_ics(booking_id: int, db: Session = Depends(get_db)):
+    """Download an iCalendar (.ics) file for a specific booking.
+
+    Returns an RFC 5545-compliant VCALENDAR file with the flight event.
+    """
+    result = booking.get_booking_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.model_dump())
+    return Response(
+        content=result,
+        media_type="text/calendar",
+        headers={"Content-Disposition": f'attachment; filename="booking-{booking_id}.ics"'},
+    )
 
 
 @app.post("/cancel/{booking_id}", response_model=Union[BookingOut, ErrorResponse], tags=["Bookings"])

--- a/booking_system_backend/services/booking.py
+++ b/booking_system_backend/services/booking.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import Session
-from datetime import datetime
+from datetime import datetime, timezone
 from models import User, Flight, Booking
 from schemas import BookingOut, ErrorResponse, SeatClass
 
@@ -126,3 +126,62 @@ def get_bookings(db: Session, user_id: int) -> list[BookingOut]:
     """Retrieve all bookings for a specific user."""
     bookings = db.query(Booking).filter(Booking.user_id == user_id).all()
     return [BookingOut.model_validate(b) for b in bookings]
+
+
+def get_booking_ics(db: Session, booking_id: int) -> str | ErrorResponse:
+    """Return an iCalendar (.ics) string for a booking.
+
+    Handles both ISO 8601 ('2099-01-01T09:00:00Z') and space-separated
+    ('2099-01-01 09:00') datetime formats stored in the database.
+    """
+    booking = db.query(Booking).filter(Booking.booking_id == booking_id).first()
+    if not booking:
+        return ErrorResponse(
+            error="Booking not found",
+            error_code="BOOKING_NOT_FOUND",
+            details=f"Booking with ID {booking_id} not found."
+        )
+
+    flight = db.query(Flight).filter(Flight.flight_id == booking.flight_id).first()
+    if not flight:
+        return ErrorResponse(
+            error="Flight not found",
+            error_code="FLIGHT_NOT_FOUND",
+            details=f"Flight with ID {booking.flight_id} not found."
+        )
+
+    def _parse_dt(raw: str) -> datetime:
+        """Parse both '2099-01-01T09:00:00Z' and '2099-01-01 09:00' formats."""
+        raw = raw.strip().rstrip("Z")
+        return datetime.fromisoformat(raw)
+
+    dtstart = _parse_dt(flight.departure_time)
+    dtend = _parse_dt(flight.arrival_time)
+    dtstamp = datetime.now(timezone.utc)
+
+    fmt = "%Y%m%dT%H%M%SZ"
+    uid = f"booking-{booking.booking_id}@galaxium-travels"
+    summary = f"Galaxium Flight: {flight.origin} → {flight.destination}"
+    description = (
+        f"Booking #{booking.booking_id} | "
+        f"Seat class: {booking.seat_class} | "
+        f"Status: {booking.status}"
+    )
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Galaxium Travels//Booking System//EN",
+        "BEGIN:VEVENT",
+        f"UID:{uid}",
+        f"DTSTAMP:{dtstamp.strftime(fmt)}",
+        f"DTSTART:{dtstart.strftime(fmt)}",
+        f"DTEND:{dtend.strftime(fmt)}",
+        f"SUMMARY:{summary}",
+        f"DESCRIPTION:{description}",
+        "END:VEVENT",
+        "END:VCALENDAR",
+    ]
+
+    # RFC 5545 requires CRLF line endings
+    return "\r\n".join(lines) + "\r\n"

--- a/booking_system_backend/tests/test_rest.py
+++ b/booking_system_backend/tests/test_rest.py
@@ -870,3 +870,49 @@ class TestFlightsEndpointFiltering:
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 2
+
+
+class TestIcsEndpoint:
+    """Test GET /bookings/{booking_id}/export.ics endpoint."""
+
+    def _seed(self, client, db_session):
+        """Register a user, create a flight, book it; return booking_id."""
+        user_resp = client.post("/register", json={"name": "Cal User", "email": "cal@example.com"})
+        user_id = user_resp.json()["user_id"]
+
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-01-01 09:00",
+            arrival_time="2099-01-01 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+        flight = db_session.query(Flight).first()
+
+        book_resp = client.post("/book", json={
+            "user_id": user_id,
+            "name": "Cal User",
+            "flight_id": flight.flight_id
+        })
+        return book_resp.json()["booking_id"]
+
+    def test_export_ics_success(self, client, db_session):
+        """Returns HTTP 200, text/calendar content-type, and valid VCALENDAR body."""
+        booking_id = self._seed(client, db_session)
+        response = client.get(f"/bookings/{booking_id}/export.ics")
+
+        assert response.status_code == 200
+        assert "text/calendar" in response.headers["content-type"]
+        body = response.text
+        assert "BEGIN:VCALENDAR" in body
+        assert "END:VCALENDAR" in body
+        assert "BEGIN:VEVENT" in body
+
+    def test_export_ics_not_found(self, client, db_session):
+        """Returns HTTP 404 for an unknown booking ID."""
+        response = client.get("/bookings/99999/export.ics")
+        assert response.status_code == 404

--- a/booking_system_backend/tests/test_services.py
+++ b/booking_system_backend/tests/test_services.py
@@ -973,3 +973,87 @@ class TestFlightFiltering:
 
         results = flight.list_flights(db_session, min_price=10000000)
         assert len(results) == 0
+
+
+class TestBookingIcsService:
+    """Test get_booking_ics service function."""
+
+    def _make_booking(self, db_session, departure_time="2099-01-01 09:00", arrival_time="2099-01-01 17:00"):
+        """Helper: insert a user, flight, and booking; return the booking object."""
+        from models import User, Flight, Booking
+        db_session.add(User(name="Ics User", email="ics@example.com"))
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time=departure_time,
+            arrival_time=arrival_time,
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000000
+        ))
+        db_session.commit()
+        return db_session.query(Booking).first()
+
+    def test_get_booking_ics_returns_valid_icalendar(self, db_session):
+        """ICS output is a well-formed VCALENDAR with required fields and CRLF endings."""
+        booking_obj = self._make_booking(db_session)
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+
+        assert isinstance(result, str)
+        assert "BEGIN:VCALENDAR" in result
+        assert "END:VCALENDAR" in result
+        assert "BEGIN:VEVENT" in result
+        assert "END:VEVENT" in result
+        assert "VERSION:2.0" in result
+        assert "PRODID:" in result
+        assert "DTSTART:" in result
+        assert "DTEND:" in result
+        assert "SUMMARY:" in result
+        assert "UID:" in result
+        # RFC 5545 strict CRLF requirement
+        assert "\r\n" in result
+
+    def test_get_booking_ics_contains_flight_details(self, db_session):
+        """ICS SUMMARY includes origin and destination."""
+        booking_obj = self._make_booking(db_session)
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+
+        assert "Earth" in result
+        assert "Mars" in result
+
+    def test_get_booking_ics_space_separated_datetime(self, db_session):
+        """Space-separated datetime format is handled correctly."""
+        booking_obj = self._make_booking(db_session, departure_time="2099-06-15 14:30", arrival_time="2099-06-15 22:00")
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+
+        assert isinstance(result, str)
+        assert "DTSTART:20990615T143000Z" in result
+        assert "DTEND:20990615T220000Z" in result
+
+    def test_get_booking_ics_iso8601_datetime(self, db_session):
+        """ISO 8601 'Z'-suffixed datetime format is handled correctly."""
+        booking_obj = self._make_booking(db_session, departure_time="2099-01-01T09:00:00Z", arrival_time="2099-01-01T17:00:00Z")
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+
+        assert isinstance(result, str)
+        assert "DTSTART:20990101T090000Z" in result
+        assert "DTEND:20990101T170000Z" in result
+
+    def test_get_booking_ics_not_found(self, db_session):
+        """Returns ErrorResponse for unknown booking ID."""
+        from schemas import ErrorResponse
+        result = booking.get_booking_ics(db_session, 99999)
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "BOOKING_NOT_FOUND"

--- a/booking_system_frontend/src/components/bookings/BookingCard.tsx
+++ b/booking_system_frontend/src/components/bookings/BookingCard.tsx
@@ -1,6 +1,6 @@
 import type { Booking, Flight } from '../../types';
 import { Card, Button } from '../common';
-import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket } from 'lucide-react';
+import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket, CalendarPlus } from 'lucide-react';
 import { formatDate, formatCurrency } from '../../utils/formatters';
 import { motion } from 'framer-motion';
 
@@ -71,6 +71,16 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
   };
 
   const canCancel = booking.status === 'booked';
+  const canExportCalendar = booking.status === 'booked';
+
+  const handleAddToCalendar = () => {
+    const base = import.meta.env.VITE_API_URL || '/api';
+    const url = `${base}/bookings/${booking.booking_id}/export.ics`;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `booking-${booking.booking_id}.ics`;
+    a.click();
+  };
 
   return (
     <motion.div
@@ -153,18 +163,30 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
           <span>Booked on {formatDate(booking.booking_time)}</span>
         </div>
 
-        {/* Cancel Button */}
-        {canCancel && (
+        {/* Action Buttons */}
+        <div className="flex flex-col gap-2">
           <Button
-            variant="danger"
+            variant="secondary"
             size="sm"
-            onClick={() => onCancel(booking.booking_id)}
-            isLoading={isCancelling}
+            onClick={handleAddToCalendar}
+            disabled={!canExportCalendar}
             className="w-full"
           >
-            Cancel Booking
+            <CalendarPlus size={16} />
+            Add to Calendar
           </Button>
-        )}
+          {canCancel && (
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => onCancel(booking.booking_id)}
+              isLoading={isCancelling}
+              className="w-full"
+            >
+              Cancel Booking
+            </Button>
+          )}
+        </div>
       </Card>
     </motion.div>
   );

--- a/demos/beginner-implementation-tasks/issue-44-implementation-plan-reviewed.md
+++ b/demos/beginner-implementation-tasks/issue-44-implementation-plan-reviewed.md
@@ -1,0 +1,39 @@
+# Issue #44 — Calendar Export (.ics) for Bookings
+
+**Status:** Draft · Reviewed
+
+## Summary
+
+The frontend download URL will use `(import.meta.env.VITE_API_URL || '/api')` as base — consistent with the existing `api.ts` pattern and proxy-safe in both dev and production. The "Add to Calendar" button will be shown on all booking cards but disabled for non-`booked` statuses, preserving visual layout consistency. The service test for the `.ics` output will include an explicit `assert '\r\n' in result` assertion to guard against silent CRLF regression.
+
+---
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Frontend download URL base | `(import.meta.env.VITE_API_URL \|\| '/api') + '/bookings/{id}/export.ics'` | Consistent with `api.ts`; works via Vite proxy in dev and direct in production without extra config. |
+| "Add to Calendar" visibility for cancelled bookings | Show disabled button | Preserves card layout consistency; disabled state signals unavailability without removing the affordance entirely. |
+| CRLF assertion in service tests | Assert `'\r\n' in result` in `test_get_booking_ics_returns_valid_icalendar` | RFC 5545 is strict about line endings; an explicit assertion catches silent regressions cheaply. |
+
+---
+
+## Open Items
+
+- **Datetime format variance:** Seed data uses both `"2099-01-01T09:00:00Z"` (ISO 8601) and `"2099-01-01 09:00"` (space-separated). The `get_booking_ics()` implementation must normalise both via `datetime.fromisoformat()` with Z-stripping — confirm test fixtures cover both formats.
+- **MCP tool placement:** New `@mcp.tool()` must be defined before `mcp_app = mcp.http_app()` at line 108 of `server.py`. Any future refactors that reorder that file risk silent tool-registration failure.
+- **Calendar client compatibility:** RFC 5545 compliance (CRLF, PRODID, VERSION) is the primary compatibility guarantee. Real-world smoke test in Apple Calendar / Google Calendar is listed in acceptance criteria but not automated — worth a manual check before closing the issue.
+- **Button disabled state styling:** The plan specifies `variant="secondary"` but does not specify how disabled looks in the existing `<Button>` component — confirm the component handles `disabled` prop visually before shipping.
+
+---
+
+## Next Steps
+
+1. Add `get_booking_ics(db, booking_id)` service function to `booking_system_backend/services/booking.py` — return `str | ErrorResponse`, build iCalendar string with CRLF, handle both ISO datetime formats.
+2. Add `GET /bookings/{booking_id}/export.ics` REST endpoint to `server.py` — return `Response(content=ics_str, media_type="text/calendar")` with `Content-Disposition` header; raise `HTTPException(404)` on error.
+3. Add `@mcp.tool() get_booking_ics(booking_id: int) -> str` to `server.py` — above `mcp_app = mcp.http_app()` (line 108).
+4. Add `handleAddToCalendar` handler and "Add to Calendar" button to `BookingCard.tsx` — use `(import.meta.env.VITE_API_URL || '/api')` base URL; show button for all statuses, disable when `booking.status !== 'booked'`; use `CalendarPlus` icon from `lucide-react`.
+5. Add `TestBookingIcsService` class to `test_services.py` — assert all required iCalendar fields **and** `'\r\n' in result`.
+6. Add `TestIcsEndpoint` class to `test_rest.py` — assert HTTP 200 / `text/calendar` / `BEGIN:VCALENDAR` for valid ID, HTTP 404 for unknown ID.
+7. Run `cd booking_system_backend && pytest` — confirm all tests pass.
+8. Manual smoke test: download `.ics` from the UI and open in Apple Calendar or Google Calendar.


### PR DESCRIPTION
# Summary

Adds iCalendar (`.ics`) export functionality for flight bookings, enabling users to download and import their booking details directly into calendar applications. This feature is implemented end-to-end: a new service function generates RFC 5545-compliant `.ics` content, a new REST endpoint serves the file for download, an MCP tool exposes the same functionality, and the frontend `BookingCard` component gains an "Add to Calendar" button. Custom AI mode definitions in `.bob/custom_modes.yaml` are also activated (uncommented).

---

# Files Changed

📄 `.bob/custom_modes.yaml`

Uncomments the entire `customModes` configuration, activating two previously disabled AI assistant modes: a read-only `Code Reviewer` and a deployment-scoped `Deploy Engineer`. No logic changes — this is purely a configuration enablement.

---

📄 `booking_system_backend/server.py`

- Imports `Response` from FastAPI to support raw HTTP responses.
- Adds a new REST endpoint `GET /bookings/{booking_id}/export.ics` that returns an RFC 5545-compliant `.ics` file with `text/calendar` content type and a `Content-Disposition` attachment header for download.
- Adds a corresponding MCP tool `get_booking_ics` that exposes the same iCalendar export capability via the MCP interface, raising an exception on error.

---

📄 `booking_system_backend/services/booking.py`

- Imports `timezone` from `datetime` for UTC-aware timestamps.
- Adds the `get_booking_ics` service function that:
  - Looks up a booking and its associated flight by ID, returning an `ErrorResponse` if either is not found.
  - Parses both ISO 8601 (`2099-01-01T09:00:00Z`) and space-separated (`2099-01-01 09:00`) datetime formats stored in the database.
  - Builds a well-formed `VCALENDAR`/`VEVENT` block with `UID`, `DTSTAMP`, `DTSTART`, `DTEND`, `SUMMARY`, and `DESCRIPTION` fields.
  - Returns the iCalendar string with RFC 5545-required CRLF line endings.

---

📄 `booking_system_backend/tests/test_rest.py`

Adds a `TestIcsEndpoint` test class covering the new `GET /bookings/{booking_id}/export.ics` REST endpoint. Includes a `_seed` helper to create a user, flight, and booking, then tests:
- **Success case**: HTTP 200, `text/calendar` content type, and valid `VCALENDAR` body structure.
- **Not found case**: HTTP 404 for an unknown booking ID.

---

📄 `booking_system_backend/tests/test_services.py`

Adds a `TestBookingIcsService` test class covering the `get_booking_ics` service function directly. Tests include:
- Valid iCalendar output with all required fields and CRLF line endings.
- Flight origin/destination present in the `SUMMARY`.
- Correct parsing of space-separated datetime format.
- Correct parsing of ISO 8601 `Z`-suffixed datetime format.
- `ErrorResponse` with `BOOKING_NOT_FOUND` error code for an unknown booking ID.

---

📄 `booking_system_frontend/src/components/bookings/BookingCard.tsx`

- Imports the `CalendarPlus` icon from `lucide-react`.
- Adds a `canExportCalendar` flag (true when booking status is `booked`).
- Adds a `handleAddToCalendar` handler that constructs the `.ics` download URL from the API base URL and programmatically triggers a file download.
- Refactors the button area into a `flex` column layout containing the new **"Add to Calendar"** secondary button (always visible for active bookings) alongside the existing **"Cancel Booking"** danger button.