### PR TITLE
WAD demo 07 changes

### DIFF
--- a/.bob/custom_modes.yaml
+++ b/.bob/custom_modes.yaml
@@ -1,47 +1,47 @@
-# customModes:
-#   - slug: code-reviewer
-#     name: Code Reviewer
-#     roleDefinition: >-
-#       You are a strict, read-only code reviewer. Your job is to read code and
-#       provide clear, actionable feedback on quality: naming conventions, code
-#       structure, consistency with project style, obvious bugs, dead code, and
-#       anything that would make the code harder to maintain or understand.
+customModes:
+  - slug: code-reviewer
+    name: Code Reviewer
+    roleDefinition: >-
+      You are a strict, read-only code reviewer. Your job is to read code and
+      provide clear, actionable feedback on quality: naming conventions, code
+      structure, consistency with project style, obvious bugs, dead code, and
+      anything that would make the code harder to maintain or understand.
 
-#       You never edit or create files. You never run the application. You may run
-#       linters and test suites to gather evidence, but only to inform your review.
+      You never edit or create files. You never run the application. You may run
+      linters and test suites to gather evidence, but only to inform your review.
 
-#       Your output is always a structured review: a short summary of findings,
-#       followed by specific issues with file references and line numbers where
-#       relevant. Distinguish between blocking issues (must fix) and suggestions
-#       (nice to have). Be direct and precise - do not pad feedback with praise.
-#     whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
-#     description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#   - slug: deploy-engineer
-#     name: Deploy Engineer
-#     roleDefinition: >-
-#       You are a Deploy Engineer. Your sole responsibility is making sure this
-#       project deploys correctly and reliably. You are an expert in the deployment
-#       scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
-#       infrastructure-as-code in this project.
+      Your output is always a structured review: a short summary of findings,
+      followed by specific issues with file references and line numbers where
+      relevant. Distinguish between blocking issues (must fix) and suggestions
+      (nice to have). Be direct and precise - do not pad feedback with praise.
+    whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
+    description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
+    groups:
+      - read
+      - execute
+      - skill
+  - slug: deploy-engineer
+    name: Deploy Engineer
+    roleDefinition: >-
+      You are a Deploy Engineer. Your sole responsibility is making sure this
+      project deploys correctly and reliably. You are an expert in the deployment
+      scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
+      infrastructure-as-code in this project.
 
-#       You only read and edit files inside the scripts/ directory. You do not
-#       touch application source code, frontend assets, or test files. If a
-#       deployment problem traces back to application code, you report it clearly
-#       but do not fix it yourself.
+      You only read and edit files inside the scripts/ directory. You do not
+      touch application source code, frontend assets, or test files. If a
+      deployment problem traces back to application code, you report it clearly
+      but do not fix it yourself.
 
-#       When reviewing or editing deploy scripts, you check for: missing error
-#       handling, hardcoded secrets or environment assumptions, non-idempotent
-#       operations, missing health checks, and steps that could cause downtime.
-#       You run commands to validate and test deploy scripts where possible.
-#     whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
-#     description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#       - - edit
-#         - fileRegex: "scripts/.*"
+      When reviewing or editing deploy scripts, you check for: missing error
+      handling, hardcoded secrets or environment assumptions, non-idempotent
+      operations, missing health checks, and steps that could cause downtime.
+      You run commands to validate and test deploy scripts where possible.
+    whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
+    description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
+    groups:
+      - read
+      - execute
+      - skill
+      - - edit
+        - fileRegex: "scripts/.*"

--- a/booking_system_backend/server.py
+++ b/booking_system_backend/server.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastmcp import FastMCP
 from sqlalchemy.orm import Session
@@ -99,6 +99,19 @@ def get_user_id(name: str, email: str) -> UserOut:
         result = user.get_user(db, name, email)
         if isinstance(result, ErrorResponse):
             raise Exception(result.details or result.error)
+        return result
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def get_booking_ics(booking_id: int) -> str:
+    """Export a booking as an iCalendar (.ics) string."""
+    db = SessionLocal()
+    try:
+        result = booking.get_booking_ics(db, booking_id)
+        if isinstance(result, ErrorResponse):
+            return f"Error: {result.error}"
         return result
     finally:
         db.close()
@@ -257,6 +270,19 @@ def cancel_booking_endpoint(booking_id: int, db: Session = Depends(get_db)):
     Increments available seats for the flight if successful.
     """
     return booking.cancel_booking(db, booking_id)
+
+
+@app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
+def export_booking_ics(booking_id: int, db: Session = Depends(get_db)):
+    """Export a booking as an iCalendar (.ics) file download."""
+    result = booking.get_booking_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.error)
+    return Response(
+        content=result,
+        media_type="text/calendar",
+        headers={"Content-Disposition": f"attachment; filename=booking-{booking_id}.ics"},
+    )
 
 
 @app.post("/register", response_model=Union[UserOut, ErrorResponse], tags=["Users"])

--- a/booking_system_backend/services/booking.py
+++ b/booking_system_backend/services/booking.py
@@ -126,3 +126,36 @@ def get_bookings(db: Session, user_id: int) -> list[BookingOut]:
     """Retrieve all bookings for a specific user."""
     bookings = db.query(Booking).filter(Booking.user_id == user_id).all()
     return [BookingOut.model_validate(b) for b in bookings]
+
+
+def _parse_dt(s: str) -> datetime:
+    """Parse a datetime string tolerating space-separator and Z/+00:00 UTC suffixes."""
+    return datetime.fromisoformat(s.replace("Z", "").replace("+00:00", "").replace(" ", "T"))
+
+
+def get_booking_ics(db: Session, booking_id: int) -> str | ErrorResponse:
+    """Return a valid iCalendar string for the given booking (RFC 5545)."""
+    b = db.query(Booking).filter(Booking.booking_id == booking_id).first()
+    if not b:
+        return ErrorResponse(error="Booking not found", error_code="BOOKING_NOT_FOUND")
+
+    f = db.query(Flight).filter(Flight.flight_id == b.flight_id).first()
+
+    dtstart = _parse_dt(f.departure_time).strftime("%Y%m%dT%H%M%SZ")
+    dtend = _parse_dt(f.arrival_time).strftime("%Y%m%dT%H%M%SZ")
+
+    # NOTE: DESCRIPTION line may exceed the RFC 5545 75-octet folding limit; acceptable for demo.
+    return (
+        "BEGIN:VCALENDAR\r\n"
+        "VERSION:2.0\r\n"
+        "PRODID:-//Galaxium Travels//EN\r\n"
+        "BEGIN:VEVENT\r\n"
+        f"UID:booking-{b.booking_id}@galaxium-travels\r\n"
+        f"SUMMARY:Galaxium Travels: {f.origin} \u2192 {f.destination}\r\n"
+        f"LOCATION:{f.origin} \u2192 {f.destination}\r\n"
+        f"DTSTART:{dtstart}\r\n"
+        f"DTEND:{dtend}\r\n"
+        f"DESCRIPTION:Booking #{b.booking_id} | Flight #{f.flight_id} | {b.seat_class} class | {b.price_paid} credits\r\n"
+        "END:VEVENT\r\n"
+        "END:VCALENDAR\r\n"
+    )

--- a/booking_system_backend/tests/test_rest.py
+++ b/booking_system_backend/tests/test_rest.py
@@ -870,3 +870,38 @@ class TestFlightsEndpointFiltering:
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 2
+
+
+class TestIcsEndpoint:
+    def _seed_booking(self, db_session):
+        from models import User, Flight, Booking
+        user = User(name="Test User", email="test@example.com")
+        db_session.add(user)
+        db_session.flush()
+        f = Flight(
+            origin="Earth", destination="Mars",
+            departure_time="2099-01-01 09:00", arrival_time="2099-01-01 17:00",
+            base_price=1000000, economy_seats_available=5,
+            business_seats_available=3, galaxium_seats_available=1,
+        )
+        db_session.add(f)
+        db_session.flush()
+        b = Booking(
+            user_id=user.user_id, flight_id=f.flight_id,
+            seat_class="economy", price_paid=1000000, status="booked",
+            booking_time="2099-01-01 10:00",
+        )
+        db_session.add(b)
+        db_session.commit()
+        return b
+
+    def test_export_ics_returns_200_with_calendar_content(self, client, db_session):
+        b = self._seed_booking(db_session)
+        response = client.get(f"/bookings/{b.booking_id}/export.ics")
+        assert response.status_code == 200
+        assert "text/calendar" in response.headers["content-type"]
+        assert "BEGIN:VCALENDAR" in response.text
+
+    def test_export_ics_returns_404_for_unknown_id(self, client, db_session):
+        response = client.get("/bookings/999999/export.ics")
+        assert response.status_code == 404

--- a/booking_system_backend/tests/test_services.py
+++ b/booking_system_backend/tests/test_services.py
@@ -973,3 +973,48 @@ class TestFlightFiltering:
 
         results = flight.list_flights(db_session, min_price=10000000)
         assert len(results) == 0
+
+
+class TestBookingIcsService:
+    def _seed(self, db_session):
+        """Seed one user, one flight, one booking and return the booking."""
+        from models import User, Flight, Booking
+        user = User(name="Test User", email="test@example.com")
+        db_session.add(user)
+        db_session.flush()
+        flight_obj = Flight(
+            origin="Earth", destination="Mars",
+            departure_time="2099-01-01 09:00", arrival_time="2099-01-01 17:00",
+            base_price=1000000, economy_seats_available=5,
+            business_seats_available=3, galaxium_seats_available=1,
+        )
+        db_session.add(flight_obj)
+        db_session.flush()
+        b = Booking(
+            user_id=user.user_id, flight_id=flight_obj.flight_id,
+            seat_class="economy", price_paid=1000000, status="booked",
+            booking_time="2099-01-01 10:00",
+        )
+        db_session.add(b)
+        db_session.commit()
+        return b
+
+    def test_get_booking_ics_returns_valid_icalendar(self, db_session):
+        b = self._seed(db_session)
+        result = booking.get_booking_ics(db_session, b.booking_id)
+        assert isinstance(result, str)
+        assert "BEGIN:VCALENDAR" in result
+        assert "BEGIN:VEVENT" in result
+        assert "SUMMARY:" in result
+        assert "DTSTART:" in result
+        assert "DTEND:" in result
+        assert "LOCATION:" in result
+        assert "DESCRIPTION:" in result
+        assert "UID:" in result
+        assert "\r\n" in result  # RFC 5545 line endings
+
+    def test_get_booking_ics_returns_error_for_unknown_id(self, db_session):
+        from schemas import ErrorResponse
+        result = booking.get_booking_ics(db_session, 999999)
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "BOOKING_NOT_FOUND"

--- a/booking_system_frontend/src/components/bookings/BookingCard.tsx
+++ b/booking_system_frontend/src/components/bookings/BookingCard.tsx
@@ -1,6 +1,6 @@
 import type { Booking, Flight } from '../../types';
 import { Card, Button } from '../common';
-import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket } from 'lucide-react';
+import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket, CalendarPlus } from 'lucide-react';
 import { formatDate, formatCurrency } from '../../utils/formatters';
 import { motion } from 'framer-motion';
 
@@ -71,6 +71,17 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
   };
 
   const canCancel = booking.status === 'booked';
+
+  const handleAddToCalendar = () => {
+    const base = import.meta.env.VITE_API_URL || '/api';
+    const url = `${base}/bookings/${booking.booking_id}/export.ics`;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `booking-${booking.booking_id}.ics`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
 
   return (
     <motion.div
@@ -153,18 +164,30 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
           <span>Booked on {formatDate(booking.booking_time)}</span>
         </div>
 
-        {/* Cancel Button */}
-        {canCancel && (
+        {/* Action Buttons */}
+        <div className="flex gap-2">
           <Button
-            variant="danger"
+            variant="secondary"
             size="sm"
-            onClick={() => onCancel(booking.booking_id)}
-            isLoading={isCancelling}
-            className="w-full"
+            onClick={handleAddToCalendar}
+            disabled={booking.status !== 'booked'}
+            className="flex-1"
           >
-            Cancel Booking
+            <CalendarPlus size={14} className="mr-1" />
+            Add to Calendar
           </Button>
-        )}
+          {canCancel && (
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => onCancel(booking.booking_id)}
+              isLoading={isCancelling}
+              className="flex-1"
+            >
+              Cancel Booking
+            </Button>
+          )}
+        </div>
       </Card>
     </motion.div>
   );

--- a/demos/beginner-implementation-tasks/issue-44-implementation-plan.md
+++ b/demos/beginner-implementation-tasks/issue-44-implementation-plan.md
@@ -1,109 +1,290 @@
 # Issue #44 — Calendar Export (.ics) for Bookings
 
-Implementation plan · ~1 hour · 4 files touched · no new dependencies
+**Status:** Ready to implement  
+**Scope:** ~1 hour · 4 files touched · no new dependencies  
+**Label:** `tier-3` · `area/fullstack`
+
+---
 
 ## Overview
 
-Add `GET /bookings/{id}/export.ics` to the Python/FastAPI backend that returns a valid iCalendar file (RFC 5545) for a booking's departure event, plus a matching MCP tool. On the frontend, add an "Add to Calendar" button to `BookingCard.tsx` that triggers a browser file download (no Axios — a temporary `<a download>` element).
+Add a `GET /bookings/{id}/export.ics` endpoint that returns a valid iCalendar file (RFC 5545), and an "Add to Calendar" button on active booking cards that triggers a browser download.
 
 ---
 
-## Implementation Steps
-
-### Step 1 — Add `get_booking_ics()` service function
-
-**File:** `booking_system_backend/services/booking.py`
-
-- New function: `get_booking_ics(db: Session, booking_id: int) -> str | ErrorResponse`
-- Joins `Booking` → `Flight` → `User` via `db.query()` (same pattern as `cancel_booking`).
-- Returns `ErrorResponse(error_code="BOOKING_NOT_FOUND")` if booking is missing.
-- Builds the iCalendar string in-memory using Python string formatting — no library needed. Required fields per acceptance criteria:
-  - `UID`: `booking-{booking_id}@galaxium-travels`
-  - `SUMMARY`: `Galaxium Flight: {origin} → {destination}`
-  - `LOCATION`: `{origin} → {destination}`
-  - `DTSTART` / `DTEND`: parse ISO-8601 departure/arrival times from the `Flight` row and reformat as `YYYYMMDDTHHMMSSZ`
-  - `DESCRIPTION`: booking ID, seat class, price, flight ID
-- Wraps the VEVENT in a minimal `VCALENDAR` envelope with `PRODID` and `VERSION:2.0`.
-- Uses `CRLF` line endings (`\r\n`) as required by RFC 5545.
-
----
-
-### Step 2 — Add REST endpoint + MCP tool
-
-**File:** `booking_system_backend/server.py`
-
-- Import `Response` from `fastapi` (already has `FastAPI`, `Depends`, `HTTPException`).
-- REST endpoint added near the other booking routes (after `/cancel/{booking_id}`):
-  ```python
-  @app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
-  ```
-  Returns `Response(content=ics_str, media_type="text/calendar", headers={"Content-Disposition": 'attachment; filename="booking-{id}.ics"'})` or raises `HTTPException(404)` on `ErrorResponse`.
-- MCP tool added near the other `@mcp.tool()` booking tools:
-  ```python
-  def get_booking_ics(booking_id: int) -> str
-  ```
-  Returns the raw iCalendar string or raises `Exception` on error. Follows the same `SessionLocal() / db.close()` pattern as all other MCP tools.
-- **Order constraint:** MCP tool must stay above `mcp_app = mcp.http_app()` (line 108) — all existing tools already respect this.
-
----
-
-### Step 3 — Add "Add to Calendar" button in `BookingCard.tsx`
-
-**File:** `booking_system_frontend/src/components/bookings/BookingCard.tsx`
-
-- Handler `handleAddToCalendar` constructs the URL `{API_BASE_URL}/bookings/{booking.booking_id}/export.ics` and triggers a download by creating a temporary `<a>` element with `href` set to the URL and `download="booking-{id}.ics"`, appending it to the DOM, clicking it, and removing it. No Axios — the browser fetches the file directly.
-- Button placed alongside the Cancel button, gated on `booking.status === 'booked'` (same guard as `canCancel`). Use the existing `<Button>` component with `variant="secondary"` and `size="sm"`. Import the `CalendarPlus` icon from `lucide-react` (already in the project's dependency tree).
-- Layout: wrap the two buttons in a `flex gap-2` container so they sit side-by-side.
-- The `API_BASE_URL` should be read from `import.meta.env.VITE_API_URL` (same as `api.ts`) — check the Vite config / existing service layer for the exact constant.
-
----
-
-### Step 4 — Write tests
-
-**Files:** `booking_system_backend/tests/test_services.py` and `test_rest.py`
-
-**Service tests** (`test_services.py`, new `TestBookingIcsService` class):
-- `test_get_booking_ics_returns_valid_icalendar` — seeds user + flight + booking, calls `booking.get_booking_ics(db, id)`, asserts `BEGIN:VCALENDAR`, `BEGIN:VEVENT`, `UID:booking-{id}@galaxium-travels`, `SUMMARY`, `LOCATION`, `DTSTART`, `DTEND`, `DESCRIPTION`, `END:VEVENT`, `END:VCALENDAR`.
-- `test_get_booking_ics_not_found` — calls with non-existent ID, asserts result is `ErrorResponse` with `error_code == "BOOKING_NOT_FOUND"`.
-
-**REST tests** (`test_rest.py`, new `TestIcsEndpoint` class):
-- `test_export_ics_200` — seeds data, `GET /bookings/{id}/export.ics`, asserts HTTP 200, `content-type: text/calendar`, body contains `BEGIN:VCALENDAR`.
-- `test_export_ics_404` — `GET /bookings/99999/export.ics`, asserts HTTP 404.
-
----
-
-## Potential Pitfalls
-
-**Datetime parsing:** Flight times are stored as strings like `"2099-01-01T09:00:00Z"` or `"2099-01-01 09:00"` (seed data uses both ISO 8601 and space-separated formats — see `conftest.py` sample data). Use `datetime.fromisoformat()` with a strip of trailing `Z` and normalise to UTC before formatting as `YYYYMMDDTHHMMSSZ`.
-
-**CRLF line endings:** RFC 5545 requires `\r\n`. Build the iCalendar string with explicit `\r\n` separators; do _not_ rely on `os.linesep`.
-
-**MCP tool placement:** The new `@mcp.tool()` function must be defined before `mcp_app = mcp.http_app()` at line 108 of `server.py`, otherwise it won't be registered (per AGENTS.md footgun).
-
-**Frontend download URL:** The `<a href>` must point to the full backend URL (e.g. `http://localhost:8001/api/bookings/{id}/export.ics`). Because the FastAPI app mounts with `root_path="/api"`, check that the Vite dev proxy (if any) correctly forwards the `/api/bookings/…` path, or use the raw `VITE_API_URL` env var as base.
-
----
-
-## Acceptance Criteria Mapping
-
-| Acceptance Criterion | Covered by |
-|---|---|
-| `GET /bookings/{id}/export.ics` → HTTP 200, `text/calendar` | Step 2 REST endpoint + Step 4 REST test |
-| `GET /bookings/{id}/export.ics` → HTTP 404 when not found | Step 2 REST endpoint + Step 4 REST test |
-| Event contains SUMMARY, LOCATION, DTSTART, DTEND, DESCRIPTION, UID | Step 1 service function + Step 4 service test |
-| Matching MCP tool added | Step 2 MCP tool |
-| "Add to Calendar" button triggers browser file download | Step 3 frontend component |
-| Opens in Apple Calendar / Google Calendar | Step 1 (RFC 5545 compliance, CRLF, PRODID) |
-| `pytest` passes with new tests | Step 4 |
-
----
-
-## Files Changed
+## Files to Touch
 
 | File | Change |
 |---|---|
-| `booking_system_backend/services/booking.py` | Add `get_booking_ics()` |
-| `booking_system_backend/server.py` | Add `GET /bookings/{id}/export.ics` endpoint + `@mcp.tool() get_booking_ics()` |
+| `booking_system_backend/services/booking.py` | Add `get_booking_ics()` service function |
+| `booking_system_backend/server.py` | Add REST endpoint + MCP tool |
 | `booking_system_backend/tests/test_services.py` | Add `TestBookingIcsService` class (2 tests) |
 | `booking_system_backend/tests/test_rest.py` | Add `TestIcsEndpoint` class (2 tests) |
-| `booking_system_frontend/src/components/bookings/BookingCard.tsx` | Add `handleAddToCalendar` + "Add to Calendar" button |
+| `booking_system_frontend/src/components/bookings/BookingCard.tsx` | Add "Add to Calendar" button |
+
+---
+
+## Step 1 — Service function (`booking.py`)
+
+Add `get_booking_ics(db: Session, booking_id: int) -> str | ErrorResponse` at the bottom of [`booking_system_backend/services/booking.py`](../../booking_system_backend/services/booking.py).
+
+**Logic:**
+
+1. Query `db.query(Booking).filter(Booking.booking_id == booking_id).first()`.
+2. If not found, return `ErrorResponse(error="BOOKING_NOT_FOUND", message="Booking not found")`.
+3. Query the related `Flight` record via `booking.flight_id`.
+4. Parse both `departure_time` and `arrival_time` using `datetime.fromisoformat()` after normalising the string:
+   ```python
+   def _parse_dt(s: str) -> datetime:
+       return datetime.fromisoformat(s.replace("Z", "").replace("+00:00", "").replace(" ", "T"))
+   ```
+   Seed data stores times as `"2099-01-01 09:00"` (space-separated, no timezone); this handles both that and ISO 8601 `Z` variants.
+5. Format timestamps as `YYYYMMDDTHHMMSSZ` by calling `.strftime("%Y%m%dT%H%M%SZ")`.
+5. Make `_parse_dt` a module-level private helper (not nested inside `get_booking_ics`) so it's reusable and independently testable.
+6. Format timestamps as `YYYYMMDDTHHMMSSZ` by calling `.strftime("%Y%m%dT%H%M%SZ")`. The `Z` suffix asserts UTC — acceptable for demo data with no real timezone context and ensures the `.ics` passes strict validator tools.
+7. Build the iCalendar string manually (no third-party library). Use `\r\n` line endings (RFC 5545 §3.1).
+8. Return the string.
+
+**iCalendar template:**
+
+```
+BEGIN:VCALENDAR\r\n
+VERSION:2.0\r\n
+PRODID:-//Galaxium Travels//EN\r\n
+BEGIN:VEVENT\r\n
+UID:booking-{booking_id}@galaxium-travels\r\n
+SUMMARY:Galaxium Travels: {origin} → {destination}\r\n
+LOCATION:{origin} → {destination}\r\n
+DTSTART:{dtstart}\r\n
+DTEND:{dtend}\r\n
+DESCRIPTION:Booking #{booking_id} | Flight #{flight_id} | {seat_class} class | {price_paid} credits\r\n
+END:VEVENT\r\n
+END:VCALENDAR\r\n
+```
+
+> **Note:** Long `DESCRIPTION` lines may exceed the RFC 5545 75-octet folding limit. For this demo codebase this is acceptable — add an inline comment noting it.
+
+---
+
+## Step 2 — REST endpoint + MCP tool (`server.py`)
+
+Two changes to [`booking_system_backend/server.py`](../../booking_system_backend/server.py):
+
+### 2a — Add `Response` to the FastAPI import (line 2)
+
+```python
+# Before
+from fastapi import FastAPI, Depends, HTTPException, Query
+
+# After
+from fastapi import FastAPI, Depends, HTTPException, Query, Response
+```
+
+### 2b — Add the MCP tool (before line 108, where `mcp_app = mcp.http_app()`)
+
+```python
+@mcp.tool()
+def get_booking_ics(booking_id: int) -> str:
+    """Export a booking as an iCalendar (.ics) string."""
+    db = SessionLocal()
+    try:
+        result = booking.get_booking_ics(db, booking_id)
+        if isinstance(result, ErrorResponse):
+            return f"Error: {result.message}"
+        return result
+    finally:
+        db.close()
+```
+
+### 2c — Add the REST endpoint (after the existing booking endpoints, before the Java proxy section)
+
+```python
+@app.get("/bookings/{booking_id}/export.ics")
+def export_booking_ics(booking_id: int, db: Session = Depends(get_db)):
+    result = booking.get_booking_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.message)
+    return Response(
+        content=result,
+        media_type="text/calendar",
+        headers={"Content-Disposition": f"attachment; filename=booking-{booking_id}.ics"},
+    )
+```
+
+---
+
+## Step 3 — Frontend button (`BookingCard.tsx`)
+
+Changes to [`booking_system_frontend/src/components/bookings/BookingCard.tsx`](../../booking_system_frontend/src/components/bookings/BookingCard.tsx):
+
+### 3a — Update imports
+
+```tsx
+// Add CalendarPlus to the lucide-react import (CalendarPlus confirmed present in pinned version)
+import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket, CalendarPlus } from 'lucide-react';
+```
+
+### 3b — Add the download handler (inside the component, after `canCancel`)
+
+```tsx
+const handleAddToCalendar = () => {
+  const base = import.meta.env.VITE_API_URL || '/api';
+  const url = `${base}/bookings/${booking.booking_id}/export.ics`;
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `booking-${booking.booking_id}.ics`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+};
+```
+
+The URL base reuses the same resolution logic as [`api.ts`](../../booking_system_frontend/src/services/api.ts) — the Vite dev proxy forwards `/api/*` to the backend, and production uses `VITE_API_URL` directly.
+
+### 3c — Replace the action buttons section (lines 156–167)
+
+Replace the current single Cancel button with a `flex` row:
+
+```tsx
+{/* Action Buttons */}
+<div className="flex gap-2">
+  <Button
+    variant="secondary"
+    size="sm"
+    onClick={handleAddToCalendar}
+    disabled={booking.status !== 'booked'}
+    className="flex-1"
+  >
+    <CalendarPlus size={14} className="mr-1" />
+    Add to Calendar
+  </Button>
+  {canCancel && (
+    <Button
+      variant="danger"
+      size="sm"
+      onClick={() => onCancel(booking.booking_id)}
+      isLoading={isCancelling}
+      className="flex-1"
+    >
+      Cancel Booking
+    </Button>
+  )}
+</div>
+```
+
+The "Add to Calendar" button is always visible but disabled for non-`booked` statuses (i.e. `cancelled` and `completed`), preserving card layout consistency. The Cancel button continues to be gated on `canCancel`.
+
+---
+
+## Step 4 — Service tests (`test_services.py`)
+
+Add `TestBookingIcsService` at the bottom of [`booking_system_backend/tests/test_services.py`](../../booking_system_backend/tests/test_services.py). Follow the existing pattern — create model instances directly via `db_session.add()`, commit, then call the service.
+
+```python
+class TestBookingIcsService:
+    def _seed(self, db_session):
+        """Seed one user, one flight, one booking and return the booking."""
+        from models import User, Flight, Booking
+        user = User(name="Test User", email="test@example.com")
+        db_session.add(user)
+        db_session.flush()
+        flight_obj = Flight(
+            origin="Earth", destination="Mars",
+            departure_time="2099-01-01 09:00", arrival_time="2099-01-01 17:00",
+            base_price=1000000, economy_seats_available=5,
+            business_seats_available=3, galaxium_seats_available=1,
+        )
+        db_session.add(flight_obj)
+        db_session.flush()
+        b = Booking(
+            user_id=user.user_id, flight_id=flight_obj.flight_id,
+            seat_class="economy", price_paid=1000000, status="booked",
+        )
+        db_session.add(b)
+        db_session.commit()
+        return b
+
+    def test_get_booking_ics_returns_valid_icalendar(self, db_session):
+        b = self._seed(db_session)
+        result = booking.get_booking_ics(db_session, b.booking_id)
+        assert isinstance(result, str)
+        assert "BEGIN:VCALENDAR" in result
+        assert "BEGIN:VEVENT" in result
+        assert "SUMMARY:" in result
+        assert "DTSTART:" in result
+        assert "DTEND:" in result
+        assert "LOCATION:" in result
+        assert "DESCRIPTION:" in result
+        assert "UID:" in result
+        assert "\r\n" in result  # RFC 5545 line endings
+
+    def test_get_booking_ics_returns_error_for_unknown_id(self, db_session):
+        from schemas import ErrorResponse
+        result = booking.get_booking_ics(db_session, 999999)
+        assert isinstance(result, ErrorResponse)
+        assert result.error == "BOOKING_NOT_FOUND"
+```
+
+---
+
+## Step 5 — REST tests (`test_rest.py`)
+
+Add `TestIcsEndpoint` at the bottom of [`booking_system_backend/tests/test_rest.py`](../../booking_system_backend/tests/test_rest.py). The `client` fixture from [`conftest.py`](../../booking_system_backend/tests/conftest.py) is available — add seed data inline using `db_session.add()`.
+
+```python
+class TestIcsEndpoint:
+    def _seed_booking(self, db_session):
+        from models import User, Flight, Booking
+        user = User(name="Test User", email="test@example.com")
+        db_session.add(user)
+        db_session.flush()
+        f = Flight(
+            origin="Earth", destination="Mars",
+            departure_time="2099-01-01 09:00", arrival_time="2099-01-01 17:00",
+            base_price=1000000, economy_seats_available=5,
+            business_seats_available=3, galaxium_seats_available=1,
+        )
+        db_session.add(f)
+        db_session.flush()
+        b = Booking(
+            user_id=user.user_id, flight_id=f.flight_id,
+            seat_class="economy", price_paid=1000000, status="booked",
+        )
+        db_session.add(b)
+        db_session.commit()
+        return b
+
+    def test_export_ics_returns_200_with_calendar_content(self, client, db_session):
+        b = self._seed_booking(db_session)
+        response = client.get(f"/bookings/{b.booking_id}/export.ics")
+        assert response.status_code == 200
+        assert "text/calendar" in response.headers["content-type"]
+        assert "BEGIN:VCALENDAR" in response.text
+
+    def test_export_ics_returns_404_for_unknown_id(self, client, db_session):
+        response = client.get("/bookings/999999/export.ics")
+        assert response.status_code == 404
+```
+
+---
+
+## Step 6 — Validate
+
+```bash
+cd booking_system_backend && pytest
+```
+
+All existing tests plus the 4 new tests must pass. Then do a manual smoke test: start the backend with seed data, visit a booking card in the UI, click "Add to Calendar", and open the downloaded `.ics` in Apple Calendar or Google Calendar.
+
+---
+
+## Acceptance Criteria Checklist
+
+- [ ] `GET /bookings/{id}/export.ics` returns HTTP 200 with `Content-Type: text/calendar` and a valid iCalendar body
+- [ ] `GET /bookings/{id}/export.ics` returns HTTP 404 when booking ID does not exist
+- [ ] Event contains `SUMMARY`, `LOCATION`, `DTSTART`, `DTEND`, `DESCRIPTION`, `UID`
+- [ ] Matching MCP tool added alongside the REST endpoint
+- [ ] "Add to Calendar" button on active booking cards triggers a browser file download
+- [ ] Button is visible on all booking cards; disabled for non-`booked` statuses
+- [ ] `cd booking_system_backend && pytest` passes with all new tests included
+- [ ] Manual smoke test: `.ics` opens correctly in Apple Calendar or Google Calendar


### PR DESCRIPTION
# Summary

Adds iCalendar (`.ics`) export functionality for bookings, allowing users to download a booking as a calendar event. This includes a new backend service function, a REST endpoint, an MCP tool, frontend UI integration with an "Add to Calendar" button, and full test coverage for both the service layer and REST API.

# Files Changed

📄 `.bob/custom_modes.yaml`

Uncomments the previously commented-out custom AI modes configuration, activating the `code-reviewer` and `deploy-engineer` modes for use in the project.

---

📄 `booking_system_backend/server.py`

- Imports `Response` from FastAPI to support custom HTTP responses.
- Adds a new MCP tool `get_booking_ics` that exposes the `.ics` export functionality via the MCP interface.
- Adds a new REST endpoint `GET /bookings/{booking_id}/export.ics` that returns the booking as a downloadable `.ics` file with the appropriate `text/calendar` content type and `Content-Disposition` header.

---

📄 `booking_system_backend/services/booking.py`

- Adds a `_parse_dt` helper to normalize datetime strings with varying formats (space separators, `Z`, `+00:00` suffixes) into Python `datetime` objects.
- Adds the `get_booking_ics` service function that queries a booking and its associated flight, then generates a valid RFC 5545 iCalendar string containing `VCALENDAR`/`VEVENT` blocks with fields for `UID`, `SUMMARY`, `LOCATION`, `DTSTART`, `DTEND`, and `DESCRIPTION`. Returns an `ErrorResponse` if the booking is not found.

---

📄 `booking_system_backend/tests/test_rest.py`

Adds a `TestIcsEndpoint` test class with:
- A `_seed_booking` helper to create a user, flight, and booking in the test database.
- A test verifying the endpoint returns HTTP 200 with `text/calendar` content type and a valid `BEGIN:VCALENDAR` body.
- A test verifying the endpoint returns HTTP 404 for an unknown booking ID.

---

📄 `booking_system_backend/tests/test_services.py`

Adds a `TestBookingIcsService` test class with:
- A `_seed` helper to set up test data.
- A test verifying that `get_booking_ics` returns a valid iCalendar string with all required RFC 5545 fields and correct `\r\n` line endings.
- A test verifying that `get_booking_ics` returns an `ErrorResponse` with `error_code="BOOKING_NOT_FOUND"` for an unknown booking ID.

---

📄 `booking_system_frontend/src/components/bookings/BookingCard.tsx`

- Imports the `CalendarPlus` icon from `lucide-react`.
- Adds a `handleAddToCalendar` handler that constructs the `.ics` export URL and triggers a file download via a programmatically clicked anchor element.
- Refactors the action button area to render both an "Add to Calendar" button (enabled only for active bookings) and the existing "Cancel Booking" button side-by-side in a flex container.