### PR TITLE
feat: implement issue-44 cancellation feature + reviewed plan

### DIFF
--- a/.bob/custom_modes.yaml
+++ b/.bob/custom_modes.yaml
@@ -1,47 +1,47 @@
-# customModes:
-#   - slug: code-reviewer
-#     name: Code Reviewer
-#     roleDefinition: >-
-#       You are a strict, read-only code reviewer. Your job is to read code and
-#       provide clear, actionable feedback on quality: naming conventions, code
-#       structure, consistency with project style, obvious bugs, dead code, and
-#       anything that would make the code harder to maintain or understand.
+customModes:
+  - slug: code-reviewer
+    name: Code Reviewer
+    roleDefinition: >-
+      You are a strict, read-only code reviewer. Your job is to read code and
+      provide clear, actionable feedback on quality: naming conventions, code
+      structure, consistency with project style, obvious bugs, dead code, and
+      anything that would make the code harder to maintain or understand.
 
-#       You never edit or create files. You never run the application. You may run
-#       linters and test suites to gather evidence, but only to inform your review.
+      You never edit or create files. You never run the application. You may run
+      linters and test suites to gather evidence, but only to inform your review.
 
-#       Your output is always a structured review: a short summary of findings,
-#       followed by specific issues with file references and line numbers where
-#       relevant. Distinguish between blocking issues (must fix) and suggestions
-#       (nice to have). Be direct and precise - do not pad feedback with praise.
-#     whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
-#     description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#   - slug: deploy-engineer
-#     name: Deploy Engineer
-#     roleDefinition: >-
-#       You are a Deploy Engineer. Your sole responsibility is making sure this
-#       project deploys correctly and reliably. You are an expert in the deployment
-#       scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
-#       infrastructure-as-code in this project.
+      Your output is always a structured review: a short summary of findings,
+      followed by specific issues with file references and line numbers where
+      relevant. Distinguish between blocking issues (must fix) and suggestions
+      (nice to have). Be direct and precise - do not pad feedback with praise.
+    whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
+    description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
+    groups:
+      - read
+      - execute
+      - skill
+  - slug: deploy-engineer
+    name: Deploy Engineer
+    roleDefinition: >-
+      You are a Deploy Engineer. Your sole responsibility is making sure this
+      project deploys correctly and reliably. You are an expert in the deployment
+      scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
+      infrastructure-as-code in this project.
 
-#       You only read and edit files inside the scripts/ directory. You do not
-#       touch application source code, frontend assets, or test files. If a
-#       deployment problem traces back to application code, you report it clearly
-#       but do not fix it yourself.
+      You only read and edit files inside the scripts/ directory. You do not
+      touch application source code, frontend assets, or test files. If a
+      deployment problem traces back to application code, you report it clearly
+      but do not fix it yourself.
 
-#       When reviewing or editing deploy scripts, you check for: missing error
-#       handling, hardcoded secrets or environment assumptions, non-idempotent
-#       operations, missing health checks, and steps that could cause downtime.
-#       You run commands to validate and test deploy scripts where possible.
-#     whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
-#     description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#       - - edit
-#         - fileRegex: "scripts/.*"
+      When reviewing or editing deploy scripts, you check for: missing error
+      handling, hardcoded secrets or environment assumptions, non-idempotent
+      operations, missing health checks, and steps that could cause downtime.
+      You run commands to validate and test deploy scripts where possible.
+    whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
+    description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
+    groups:
+      - read
+      - execute
+      - skill
+      - - edit
+        - fileRegex: "scripts/.*"

--- a/booking_system_backend/server.py
+++ b/booking_system_backend/server.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastmcp import FastMCP
 from sqlalchemy.orm import Session
@@ -97,6 +97,21 @@ def get_user_id(name: str, email: str) -> UserOut:
     db = SessionLocal()
     try:
         result = user.get_user(db, name, email)
+        if isinstance(result, ErrorResponse):
+            raise Exception(result.details or result.error)
+        return result
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def export_booking_ics(booking_id: int) -> str:
+    """Export a booking as an iCalendar (.ics) string.
+    Returns a valid VCALENDAR document for the given booking_id,
+    or raises an error if the booking does not exist."""
+    db = SessionLocal()
+    try:
+        result = booking.export_booking_ics(db, booking_id)
         if isinstance(result, ErrorResponse):
             raise Exception(result.details or result.error)
         return result
@@ -257,6 +272,19 @@ def cancel_booking_endpoint(booking_id: int, db: Session = Depends(get_db)):
     Increments available seats for the flight if successful.
     """
     return booking.cancel_booking(db, booking_id)
+
+
+@app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
+def export_booking_ics_endpoint(booking_id: int, db: Session = Depends(get_db)):
+    """Export a booking as an iCalendar (.ics) file download."""
+    result = booking.export_booking_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.error)
+    return Response(
+        content=result,
+        media_type="text/calendar",
+        headers={"Content-Disposition": f"attachment; filename=booking-{booking_id}.ics"}
+    )
 
 
 @app.post("/register", response_model=Union[UserOut, ErrorResponse], tags=["Users"])

--- a/booking_system_backend/services/booking.py
+++ b/booking_system_backend/services/booking.py
@@ -126,3 +126,37 @@ def get_bookings(db: Session, user_id: int) -> list[BookingOut]:
     """Retrieve all bookings for a specific user."""
     bookings = db.query(Booking).filter(Booking.user_id == user_id).all()
     return [BookingOut.model_validate(b) for b in bookings]
+
+
+def export_booking_ics(db: Session, booking_id: int) -> str | ErrorResponse:
+    """Export a booking as an iCalendar (.ics) string."""
+    booking_obj = db.query(Booking).filter(Booking.booking_id == booking_id).first()
+    if not booking_obj:
+        return ErrorResponse(
+            error="Booking not found",
+            error_code="BOOKING_NOT_FOUND",
+            details=f"Booking with ID {booking_id} not found."
+        )
+
+    flight_obj = db.query(Flight).filter(Flight.flight_id == booking_obj.flight_id).first()
+
+    dtstart = datetime.strptime(flight_obj.departure_time, "%Y-%m-%d %H:%M").strftime("%Y%m%dT%H%M%SZ")
+    dtend = datetime.strptime(flight_obj.arrival_time, "%Y-%m-%d %H:%M").strftime("%Y%m%dT%H%M%SZ")
+    dtstamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+    ics = (
+        "BEGIN:VCALENDAR\r\n"
+        "VERSION:2.0\r\n"
+        "PRODID:-//Galaxium Travels//EN\r\n"
+        "BEGIN:VEVENT\r\n"
+        f"UID:booking-{booking_id}@galaxium.travels\r\n"
+        f"DTSTAMP:{dtstamp}\r\n"
+        f"DTSTART:{dtstart}\r\n"
+        f"DTEND:{dtend}\r\n"
+        f"SUMMARY:Galaxium Flight: {flight_obj.origin} \u2192 {flight_obj.destination}\r\n"
+        f"LOCATION:{flight_obj.origin} \u2192 {flight_obj.destination}\r\n"
+        f"DESCRIPTION:Booking #{booking_id} \u00b7 {booking_obj.seat_class} class \u00b7 {booking_obj.price_paid} GXC\r\n"
+        "END:VEVENT\r\n"
+        "END:VCALENDAR\r\n"
+    )
+    return ics

--- a/booking_system_backend/tests/test_rest.py
+++ b/booking_system_backend/tests/test_rest.py
@@ -415,6 +415,49 @@ class TestCancelEndpoint:
         assert data["error_code"] == "BOOKING_NOT_FOUND"
 
 
+class TestExportIcsEndpoint:
+    """Test /bookings/{id}/export.ics endpoint."""
+
+    def test_export_ics_endpoint_200(self, client, db_session, sample_user_data):
+        """Test that a valid booking returns HTTP 200 with text/calendar content."""
+        user_response = client.post("/register", json=sample_user_data)
+        user_id = user_response.json()["user_id"]
+
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-01-01 09:00",
+            arrival_time="2099-01-01 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+        flight = db_session.query(Flight).first()
+
+        db_session.add(Booking(
+            user_id=user_id,
+            flight_id=flight.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000000
+        ))
+        db_session.commit()
+        booking_obj = db_session.query(Booking).first()
+
+        response = client.get(f"/bookings/{booking_obj.booking_id}/export.ics")
+        assert response.status_code == 200
+        assert "text/calendar" in response.headers["content-type"]
+        assert "BEGIN:VCALENDAR" in response.text
+
+    def test_export_ics_endpoint_404(self, client, db_session):
+        """Test that a non-existent booking returns HTTP 404."""
+        response = client.get("/bookings/99999/export.ics")
+        assert response.status_code == 404
+
+
 class TestHealthEndpoint:
     """Test health check endpoint."""
 

--- a/booking_system_backend/tests/test_services.py
+++ b/booking_system_backend/tests/test_services.py
@@ -482,6 +482,50 @@ class TestBookingService:
         result = booking.get_bookings(db_session, 999)
         assert result == []
 
+    def test_export_ics_valid_booking(self, db_session):
+        """Test exporting a valid booking as iCalendar string."""
+        db_session.add(User(name="Test User", email="test@example.com"))
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-01-01 09:00",
+            arrival_time="2099-01-01 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000000
+        ))
+        db_session.commit()
+
+        booking_obj = db_session.query(Booking).first()
+        result = booking.export_booking_ics(db_session, booking_obj.booking_id)
+
+        assert isinstance(result, str)
+        assert "BEGIN:VCALENDAR" in result
+        assert "BEGIN:VEVENT" in result
+        assert f"UID:booking-{booking_obj.booking_id}@galaxium.travels" in result
+        assert "SUMMARY:Galaxium Flight: Earth" in result
+        assert "LOCATION:Earth" in result
+
+    def test_export_ics_booking_not_found(self, db_session):
+        """Test exporting a non-existent booking returns ErrorResponse."""
+        result = booking.export_booking_ics(db_session, 999)
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "BOOKING_NOT_FOUND"
+
 
 
 class TestFlightFiltering:

--- a/booking_system_frontend/src/components/bookings/BookingCard.tsx
+++ b/booking_system_frontend/src/components/bookings/BookingCard.tsx
@@ -72,6 +72,13 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
 
   const canCancel = booking.status === 'booked';
 
+  const handleAddToCalendar = () => {
+    const a = document.createElement('a');
+    a.href = `/api/bookings/${booking.booking_id}/export.ics`;
+    a.download = `booking-${booking.booking_id}.ics`;
+    a.click();
+  };
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -153,14 +160,24 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
           <span>Booked on {formatDate(booking.booking_time)}</span>
         </div>
 
-        {/* Cancel Button */}
+        {/* Calendar & Cancel Buttons */}
+        {booking.status === 'booked' && (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleAddToCalendar}
+            className="w-full"
+          >
+            Add to Calendar
+          </Button>
+        )}
         {canCancel && (
           <Button
             variant="danger"
             size="sm"
             onClick={() => onCancel(booking.booking_id)}
             isLoading={isCancelling}
-            className="w-full"
+            className="w-full mt-2"
           >
             Cancel Booking
           </Button>

--- a/demos/beginner-implementation-tasks/issue-44-implementation-plan-reviewed.md
+++ b/demos/beginner-implementation-tasks/issue-44-implementation-plan-reviewed.md
@@ -1,0 +1,53 @@
+# Issue #44 — Calendar Export (.ics) for Bookings — Reviewed
+
+**Status:** Draft · Reviewed  
+**Tier:** 3 · ~1 hour · Full-stack (backend + frontend)
+
+---
+
+## Summary
+
+The plan is sound and ready to implement. Flight times are stored as UTC in the SQLite DB, so appending the literal `Z` suffix in the iCalendar output is correct. The `/api` prefix is already proxied in Vite dev and production, meaning the frontend `<a href="/api/bookings/…">` download link will work without changes. Test fixtures must create a `User` and `Flight` row before inserting a `Booking` due to FK constraints — the existing `TestBookingService` tests provide an exact pattern to follow.
+
+---
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Timezone handling in iCalendar output | Append literal `Z` (UTC) suffix | Flight times are stored as UTC in the DB; no conversion needed. Matches RFC 5545 UTC-offset notation. |
+| Frontend API path for .ics download | Use `/api/bookings/{id}/export.ics` relative path | The `/api` prefix is already proxied by Vite in dev and by nginx/routing in production — no absolute URL or env var needed. |
+| Test fixture setup for ICS service tests | Create `User` + `Flight` + `Booking` inline per test | `Booking` has FK constraints on both `user_id` and `flight_id`; existing `TestBookingService` tests show the exact pattern to follow. |
+
+---
+
+## Open Items
+
+- The plan spec does not include a `DTSTAMP` value in the example skeleton — implementers should use `datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")` for the current timestamp as required by RFC 5545.
+- The acceptance criterion "File opens correctly in Apple Calendar and Google Calendar" cannot be validated by automated tests — manual smoke-test is required before closing the issue.
+- No e2e test coverage is specified for the calendar export flow; consider adding a `test_smoke.py` assertion for the `Content-Type: text/calendar` header if e2e coverage of new endpoints is desired.
+- `error_code` in the MCP tool references `result.details` — verify that `ErrorResponse` has a `details` field (the REST path only uses `result.error`).
+
+---
+
+## Next Steps
+
+1. Add `export_booking_ics(db, booking_id) -> str | ErrorResponse` to `booking_system_backend/services/booking.py`, including `DTSTAMP` with current UTC time.
+2. Add the REST endpoint `GET /bookings/{booking_id}/export.ics` to `server.py` (import `Response` from `fastapi`).
+3. Add the matching MCP tool `export_booking_ics` to `server.py` before the `mcp_app = mcp.http_app()` line.
+4. Add 2 service-level tests to `test_services.py` and 2 REST-level tests to `test_rest.py`, following the existing `TestBookingService` fixture pattern (User + Flight + Booking inline).
+5. Add the "Add to Calendar" button to `BookingCard.tsx`, gated on `booking.status === 'booked'`, above the Cancel button.
+6. Run `cd booking_system_backend && pytest` and `cd booking_system_frontend && npm run lint` to validate.
+7. Manually open the downloaded `.ics` file in Apple Calendar and Google Calendar to satisfy the last acceptance criterion.
+
+---
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `booking_system_backend/services/booking.py` | + `export_booking_ics()` |
+| `booking_system_backend/server.py` | + `export_booking_ics` MCP tool + REST endpoint |
+| `booking_system_backend/tests/test_services.py` | + 2 service tests |
+| `booking_system_backend/tests/test_rest.py` | + 2 REST tests |
+| `booking_system_frontend/src/components/bookings/BookingCard.tsx` | + "Add to Calendar" button |

--- a/demos/beginner-implementation-tasks/issue-44-implementation-plan.md
+++ b/demos/beginner-implementation-tasks/issue-44-implementation-plan.md
@@ -1,109 +1,189 @@
 # Issue #44 — Calendar Export (.ics) for Bookings
 
-Implementation plan · ~1 hour · 4 files touched · no new dependencies
+> **Tier 3 · ~1 hour · Full-stack (backend + frontend)**
 
-## Overview
+## Goal
 
-Add `GET /bookings/{id}/export.ics` to the Python/FastAPI backend that returns a valid iCalendar file (RFC 5545) for a booking's departure event, plus a matching MCP tool. On the frontend, add an "Add to Calendar" button to `BookingCard.tsx` that triggers a browser file download (no Axios — a temporary `<a download>` element).
-
----
-
-## Implementation Steps
-
-### Step 1 — Add `get_booking_ics()` service function
-
-**File:** `booking_system_backend/services/booking.py`
-
-- New function: `get_booking_ics(db: Session, booking_id: int) -> str | ErrorResponse`
-- Joins `Booking` → `Flight` → `User` via `db.query()` (same pattern as `cancel_booking`).
-- Returns `ErrorResponse(error_code="BOOKING_NOT_FOUND")` if booking is missing.
-- Builds the iCalendar string in-memory using Python string formatting — no library needed. Required fields per acceptance criteria:
-  - `UID`: `booking-{booking_id}@galaxium-travels`
-  - `SUMMARY`: `Galaxium Flight: {origin} → {destination}`
-  - `LOCATION`: `{origin} → {destination}`
-  - `DTSTART` / `DTEND`: parse ISO-8601 departure/arrival times from the `Flight` row and reformat as `YYYYMMDDTHHMMSSZ`
-  - `DESCRIPTION`: booking ID, seat class, price, flight ID
-- Wraps the VEVENT in a minimal `VCALENDAR` envelope with `PRODID` and `VERSION:2.0`.
-- Uses `CRLF` line endings (`\r\n`) as required by RFC 5545.
+Add a `GET /bookings/{id}/export.ics` endpoint and an "Add to Calendar" button on the
+`BookingCard` so users can save a flight event to Apple Calendar or Google Calendar
+directly from the My Bookings page.
 
 ---
 
-### Step 2 — Add REST endpoint + MCP tool
+## What to build
 
-**File:** `booking_system_backend/server.py`
+### 1. Service function — `booking_system_backend/services/booking.py`
 
-- Import `Response` from `fastapi` (already has `FastAPI`, `Depends`, `HTTPException`).
-- REST endpoint added near the other booking routes (after `/cancel/{booking_id}`):
-  ```python
-  @app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
-  ```
-  Returns `Response(content=ics_str, media_type="text/calendar", headers={"Content-Disposition": 'attachment; filename="booking-{id}.ics"'})` or raises `HTTPException(404)` on `ErrorResponse`.
-- MCP tool added near the other `@mcp.tool()` booking tools:
-  ```python
-  def get_booking_ics(booking_id: int) -> str
-  ```
-  Returns the raw iCalendar string or raises `Exception` on error. Follows the same `SessionLocal() / db.close()` pattern as all other MCP tools.
-- **Order constraint:** MCP tool must stay above `mcp_app = mcp.http_app()` (line 108) — all existing tools already respect this.
+Add a new function `export_booking_ics(db, booking_id) -> str | ErrorResponse`.
 
----
+- Query the `Booking` by `booking_id`; return an `ErrorResponse` (`BOOKING_NOT_FOUND`) if
+  it doesn't exist.
+- Join on the `Flight` to get `origin`, `destination`, `departure_time`, `arrival_time`.
+- Build a plain-text iCalendar string (RFC 5545) — no third-party library needed.
 
-### Step 3 — Add "Add to Calendar" button in `BookingCard.tsx`
+Required VEVENT fields:
 
-**File:** `booking_system_frontend/src/components/bookings/BookingCard.tsx`
+| Field         | Value                                                             |
+|---------------|-------------------------------------------------------------------|
+| `UID`         | `booking-{booking_id}@galaxium.travels`                          |
+| `SUMMARY`     | `Galaxium Flight: {origin} → {destination}`                      |
+| `LOCATION`    | `{origin} → {destination}`                                       |
+| `DTSTART`     | `departure_time` converted to `YYYYMMDDTHHmmssZ` format          |
+| `DTEND`       | `arrival_time` converted to `YYYYMMDDTHHmmssZ` format            |
+| `DESCRIPTION` | `Booking #{booking_id} · {seat_class} class · {price_paid} GXC`  |
 
-- Handler `handleAddToCalendar` constructs the URL `{API_BASE_URL}/bookings/{booking.booking_id}/export.ics` and triggers a download by creating a temporary `<a>` element with `href` set to the URL and `download="booking-{id}.ics"`, appending it to the DOM, clicking it, and removing it. No Axios — the browser fetches the file directly.
-- Button placed alongside the Cancel button, gated on `booking.status === 'booked'` (same guard as `canCancel`). Use the existing `<Button>` component with `variant="secondary"` and `size="sm"`. Import the `CalendarPlus` icon from `lucide-react` (already in the project's dependency tree).
-- Layout: wrap the two buttons in a `flex gap-2` container so they sit side-by-side.
-- The `API_BASE_URL` should be read from `import.meta.env.VITE_API_URL` (same as `api.ts`) — check the Vite config / existing service layer for the exact constant.
+Minimal iCal skeleton:
 
----
+```
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Galaxium Travels//EN
+BEGIN:VEVENT
+UID:...
+DTSTAMP:...
+DTSTART:...
+DTEND:...
+SUMMARY:...
+LOCATION:...
+DESCRIPTION:...
+END:VEVENT
+END:VCALENDAR
+```
 
-### Step 4 — Write tests
-
-**Files:** `booking_system_backend/tests/test_services.py` and `test_rest.py`
-
-**Service tests** (`test_services.py`, new `TestBookingIcsService` class):
-- `test_get_booking_ics_returns_valid_icalendar` — seeds user + flight + booking, calls `booking.get_booking_ics(db, id)`, asserts `BEGIN:VCALENDAR`, `BEGIN:VEVENT`, `UID:booking-{id}@galaxium-travels`, `SUMMARY`, `LOCATION`, `DTSTART`, `DTEND`, `DESCRIPTION`, `END:VEVENT`, `END:VCALENDAR`.
-- `test_get_booking_ics_not_found` — calls with non-existent ID, asserts result is `ErrorResponse` with `error_code == "BOOKING_NOT_FOUND"`.
-
-**REST tests** (`test_rest.py`, new `TestIcsEndpoint` class):
-- `test_export_ics_200` — seeds data, `GET /bookings/{id}/export.ics`, asserts HTTP 200, `content-type: text/calendar`, body contains `BEGIN:VCALENDAR`.
-- `test_export_ics_404` — `GET /bookings/99999/export.ics`, asserts HTTP 404.
-
----
-
-## Potential Pitfalls
-
-**Datetime parsing:** Flight times are stored as strings like `"2099-01-01T09:00:00Z"` or `"2099-01-01 09:00"` (seed data uses both ISO 8601 and space-separated formats — see `conftest.py` sample data). Use `datetime.fromisoformat()` with a strip of trailing `Z` and normalise to UTC before formatting as `YYYYMMDDTHHMMSSZ`.
-
-**CRLF line endings:** RFC 5545 requires `\r\n`. Build the iCalendar string with explicit `\r\n` separators; do _not_ rely on `os.linesep`.
-
-**MCP tool placement:** The new `@mcp.tool()` function must be defined before `mcp_app = mcp.http_app()` at line 108 of `server.py`, otherwise it won't be registered (per AGENTS.md footgun).
-
-**Frontend download URL:** The `<a href>` must point to the full backend URL (e.g. `http://localhost:8001/api/bookings/{id}/export.ics`). Because the FastAPI app mounts with `root_path="/api"`, check that the Vite dev proxy (if any) correctly forwards the `/api/bookings/…` path, or use the raw `VITE_API_URL` env var as base.
+`departure_time` and `arrival_time` are stored as `"YYYY-MM-DD HH:MM"` in the DB — parse
+with `datetime.strptime(val, "%Y-%m-%d %H:%M")` and format with `strftime("%Y%m%dT%H%M%SZ")`.
 
 ---
 
-## Acceptance Criteria Mapping
+### 2. REST endpoint — `booking_system_backend/server.py`
 
-| Acceptance Criterion | Covered by |
-|---|---|
-| `GET /bookings/{id}/export.ics` → HTTP 200, `text/calendar` | Step 2 REST endpoint + Step 4 REST test |
-| `GET /bookings/{id}/export.ics` → HTTP 404 when not found | Step 2 REST endpoint + Step 4 REST test |
-| Event contains SUMMARY, LOCATION, DTSTART, DTEND, DESCRIPTION, UID | Step 1 service function + Step 4 service test |
-| Matching MCP tool added | Step 2 MCP tool |
-| "Add to Calendar" button triggers browser file download | Step 3 frontend component |
-| Opens in Apple Calendar / Google Calendar | Step 1 (RFC 5545 compliance, CRLF, PRODID) |
-| `pytest` passes with new tests | Step 4 |
+```python
+@app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
+def export_booking_ics(booking_id: int, db: Session = Depends(get_db)):
+    result = booking.export_booking_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.error)
+    return Response(
+        content=result,
+        media_type="text/calendar",
+        headers={"Content-Disposition": f"attachment; filename=booking-{booking_id}.ics"}
+    )
+```
+
+Import `Response` from `fastapi` at the top of the file.
 
 ---
 
-## Files Changed
+### 3. MCP tool — `booking_system_backend/server.py`
+
+Per project convention, every REST endpoint needs a matching MCP tool. Add it **before**
+the `mcp_app = mcp.http_app()` line:
+
+```python
+@mcp.tool()
+def export_booking_ics(booking_id: int) -> str:
+    """Export a booking as an iCalendar (.ics) string.
+    Returns a valid VCALENDAR document for the given booking_id,
+    or raises an error if the booking does not exist."""
+    db = SessionLocal()
+    try:
+        result = booking.export_booking_ics(db, booking_id)
+        if isinstance(result, ErrorResponse):
+            raise Exception(result.details or result.error)
+        return result
+    finally:
+        db.close()
+```
+
+---
+
+### 4. Tests — `booking_system_backend/tests/`
+
+Add to **`test_services.py`** (service-level, uses `db_session`):
+
+| Test | Asserts |
+|------|---------|
+| `test_export_ics_valid_booking` | Returns a `str`; contains `BEGIN:VCALENDAR`, `BEGIN:VEVENT`, correct `UID`, `SUMMARY`, `LOCATION` |
+| `test_export_ics_booking_not_found` | Returns `ErrorResponse` with `error_code == "BOOKING_NOT_FOUND"` |
+
+Add to **`test_rest.py`** (REST-level, uses `client`):
+
+| Test | Asserts |
+|------|---------|
+| `test_export_ics_endpoint_200` | `GET /bookings/{id}/export.ics` → HTTP 200, `Content-Type: text/calendar`, body contains `BEGIN:VCALENDAR` |
+| `test_export_ics_endpoint_404` | Non-existent ID → HTTP 404 |
+
+Both test files already have the seed fixtures and patterns to follow — create a `Flight`
+and a `Booking` inline, then call the endpoint or service function.
+
+---
+
+### 5. Frontend — `booking_system_frontend/src/components/bookings/BookingCard.tsx`
+
+Add a calendar download handler and an "Add to Calendar" button alongside the
+existing Cancel button, gated on `booking.status === 'booked'`:
+
+```tsx
+const handleAddToCalendar = () => {
+  const a = document.createElement('a');
+  a.href = `/api/bookings/${booking.booking_id}/export.ics`;
+  a.download = `booking-${booking.booking_id}.ics`;
+  a.click();
+};
+```
+
+Render the button inside the `canCancel` block (or unconditionally for `'booked'` status):
+
+```tsx
+{booking.status === 'booked' && (
+  <Button
+    variant="secondary"
+    size="sm"
+    onClick={handleAddToCalendar}
+    className="w-full"
+  >
+    Add to Calendar
+  </Button>
+)}
+```
+
+Place it **above** the Cancel button so it reads logically (calendar → cancel).
+
+> The download is triggered via a temporary `<a download>` element — **not** Axios —
+> because the browser must handle the file download natively.
+
+---
+
+## Files touched
 
 | File | Change |
-|---|---|
-| `booking_system_backend/services/booking.py` | Add `get_booking_ics()` |
-| `booking_system_backend/server.py` | Add `GET /bookings/{id}/export.ics` endpoint + `@mcp.tool() get_booking_ics()` |
-| `booking_system_backend/tests/test_services.py` | Add `TestBookingIcsService` class (2 tests) |
-| `booking_system_backend/tests/test_rest.py` | Add `TestIcsEndpoint` class (2 tests) |
-| `booking_system_frontend/src/components/bookings/BookingCard.tsx` | Add `handleAddToCalendar` + "Add to Calendar" button |
+|------|--------|
+| `booking_system_backend/services/booking.py` | + `export_booking_ics()` |
+| `booking_system_backend/server.py` | + `export_booking_ics` MCP tool + REST endpoint |
+| `booking_system_backend/tests/test_services.py` | + 2 service tests |
+| `booking_system_backend/tests/test_rest.py` | + 2 REST tests |
+| `booking_system_frontend/src/components/bookings/BookingCard.tsx` | + "Add to Calendar" button |
+
+---
+
+## Acceptance criteria (from issue)
+
+- [ ] `GET /bookings/{id}/export.ics` → HTTP 200 with `Content-Type: text/calendar` and a valid iCalendar body
+- [ ] `GET /bookings/{id}/export.ics` → HTTP 404 when booking ID does not exist
+- [ ] VEVENT contains `SUMMARY`, `LOCATION`, `DTSTART`, `DTEND`, `DESCRIPTION`, `UID`
+- [ ] Matching MCP tool added alongside the REST endpoint
+- [ ] "Add to Calendar" button on active booking cards triggers a browser file download
+- [ ] File opens correctly in Apple Calendar and Google Calendar
+- [ ] `cd booking_system_backend && pytest` passes with new tests included
+
+---
+
+## Validation
+
+```bash
+# Run the full backend test suite
+cd booking_system_backend && pytest
+
+# Lint the frontend
+cd booking_system_frontend && npm run lint
+```


### PR DESCRIPTION
# Summary

Adds iCalendar (`.ics`) export functionality for bookings, allowing users to download their flight booking details and add them to a calendar application. This feature is exposed via a new REST API endpoint, an MCP tool, and a frontend "Add to Calendar" button on each booking card. Tests are added for both the service layer and the REST endpoint. Additionally, the Bob AI custom modes configuration is uncommented and activated.

# Files Changed

📄 `.bob/custom_modes.yaml`

Uncomments the entire custom modes configuration, activating two previously disabled AI assistant modes: `code-reviewer` (a read-only code quality reviewer) and `deploy-engineer` (a deployment-focused engineer scoped to the `scripts/` directory).

---

📄 `booking_system_backend/server.py`

- Adds `Response` to the FastAPI imports to support returning raw HTTP responses.
- Registers a new MCP tool `export_booking_ics` that calls the booking service and returns the `.ics` string, raising an exception on error.
- Adds a new REST `GET /bookings/{booking_id}/export.ics` endpoint that returns the iCalendar file as a `text/calendar` download response, returning a 404 if the booking is not found.

---

📄 `booking_system_backend/services/booking.py`

Implements the `export_booking_ics` service function. It queries the database for the booking and its associated flight, then constructs and returns a valid `VCALENDAR`/`VEVENT` iCalendar string including flight origin/destination, departure/arrival times, seat class, and price. Returns an `ErrorResponse` if the booking does not exist.

---

📄 `booking_system_backend/tests/test_rest.py`

Adds a `TestExportIcsEndpoint` test class with two tests:
- `test_export_ics_endpoint_200`: Verifies that a valid booking returns HTTP 200 with `text/calendar` content type and a `BEGIN:VCALENDAR` body.
- `test_export_ics_endpoint_404`: Verifies that a request for a non-existent booking returns HTTP 404.

---

📄 `booking_system_backend/tests/test_services.py`

Adds two tests to `TestBookingService`:
- `test_export_ics_valid_booking`: Verifies that the service returns a valid iCalendar string containing the expected `VCALENDAR`, `VEVENT`, `UID`, `SUMMARY`, and `LOCATION` fields.
- `test_export_ics_booking_not_found`: Verifies that the service returns an `ErrorResponse` with error code `BOOKING_NOT_FOUND` for a non-existent booking ID.

---

📄 `booking_system_frontend/src/components/bookings/BookingCard.tsx`

- Adds a `handleAddToCalendar` function that programmatically triggers a download of the `.ics` file by creating and clicking a temporary anchor element pointed at the export endpoint.
- Renders a new "Add to Calendar" secondary button above the "Cancel Booking" button, visible only when the booking status is `booked`.
- Adds a small top margin (`mt-2`) to the cancel button to visually separate it from the new calendar button.