### PR TITLE
feat: add calendar export (.ics) for bookings

### DIFF
--- a/booking_system_backend/server.py
+++ b/booking_system_backend/server.py
@@ -7,6 +7,7 @@ from typing import Union, Optional
 from dotenv import load_dotenv
 import os
 import httpx
+from fastapi.responses import Response
 from db import SessionLocal, init_db, get_db
 from seed import seed
 from services import flight, user, booking
@@ -69,6 +70,21 @@ def cancel_booking(booking_id: int) -> BookingOut:
     db = SessionLocal()
     try:
         result = booking.cancel_booking(db, booking_id)
+        if isinstance(result, ErrorResponse):
+            raise Exception(result.details or result.error)
+        return result
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def get_booking_ics(booking_id: int) -> str:
+    """Generate an iCalendar (.ics) file content for a specific booking.
+    Returns the raw .ics text that can be saved as a file and opened in any calendar application.
+    Raises an error if the booking or associated flight is not found."""
+    db = SessionLocal()
+    try:
+        result = booking.get_booking_ics(db, booking_id)
         if isinstance(result, ErrorResponse):
             raise Exception(result.details or result.error)
         return result
@@ -257,6 +273,19 @@ def cancel_booking_endpoint(booking_id: int, db: Session = Depends(get_db)):
     Increments available seats for the flight if successful.
     """
     return booking.cancel_booking(db, booking_id)
+
+
+@app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
+def export_booking_ics(booking_id: int, db: Session = Depends(get_db)):
+    """Export a booking as an iCalendar (.ics) file for adding to a calendar application."""
+    result = booking.get_booking_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.model_dump())
+    return Response(
+        content=result,
+        media_type="text/calendar",
+        headers={"Content-Disposition": f'attachment; filename="booking-{booking_id}.ics"'},
+    )
 
 
 @app.post("/register", response_model=Union[UserOut, ErrorResponse], tags=["Users"])

--- a/booking_system_backend/services/booking.py
+++ b/booking_system_backend/services/booking.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import Session
-from datetime import datetime
+from datetime import datetime, timezone
 from models import User, Flight, Booking
 from schemas import BookingOut, ErrorResponse, SeatClass
 
@@ -126,3 +126,55 @@ def get_bookings(db: Session, user_id: int) -> list[BookingOut]:
     """Retrieve all bookings for a specific user."""
     bookings = db.query(Booking).filter(Booking.user_id == user_id).all()
     return [BookingOut.model_validate(b) for b in bookings]
+
+
+def get_booking_ics(db: Session, booking_id: int) -> str | ErrorResponse:
+    """Generate an iCalendar (.ics) file content for a specific booking."""
+    booking = db.query(Booking).filter(Booking.booking_id == booking_id).first()
+    if not booking:
+        return ErrorResponse(
+            error="Booking not found",
+            error_code="BOOKING_NOT_FOUND",
+            details=f"Booking with ID {booking_id} not found."
+        )
+
+    flight = db.query(Flight).filter(Flight.flight_id == booking.flight_id).first()
+    if not flight:
+        return ErrorResponse(
+            error="Flight not found",
+            error_code="FLIGHT_NOT_FOUND",
+            details=f"Flight with ID {booking.flight_id} not found."
+        )
+
+    departure_dt = datetime.strptime(flight.departure_time, "%Y-%m-%d %H:%M")
+    arrival_dt = datetime.strptime(flight.arrival_time, "%Y-%m-%d %H:%M")
+
+    def fmt_ics_dt(dt: datetime) -> str:
+        return dt.strftime("%Y%m%dT%H%M%SZ")
+
+    uid = f"booking-{booking.booking_id}@galaxium-travels"
+    dtstart = fmt_ics_dt(departure_dt)
+    dtend = fmt_ics_dt(arrival_dt)
+    summary = f"Galaxium Flight: {flight.origin} → {flight.destination}"
+    location = f"{flight.origin} to {flight.destination}"
+    description = (
+        f"Booking #{booking.booking_id} | "
+        f"Seat class: {booking.seat_class} | "
+        f"Price paid: {booking.price_paid}"
+    )
+
+    ics = (
+        "BEGIN:VCALENDAR\r\n"
+        "VERSION:2.0\r\n"
+        "PRODID:-//Galaxium Travels//Booking Export//EN\r\n"
+        "BEGIN:VEVENT\r\n"
+        f"UID:{uid}\r\n"
+        f"SUMMARY:{summary}\r\n"
+        f"LOCATION:{location}\r\n"
+        f"DTSTART:{dtstart}\r\n"
+        f"DTEND:{dtend}\r\n"
+        f"DESCRIPTION:{description}\r\n"
+        "END:VEVENT\r\n"
+        "END:VCALENDAR\r\n"
+    )
+    return ics

--- a/booking_system_backend/tests/test_rest.py
+++ b/booking_system_backend/tests/test_rest.py
@@ -870,3 +870,52 @@ class TestFlightsEndpointFiltering:
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 2
+
+
+class TestExportBookingIcs:
+    """Test GET /bookings/{booking_id}/export.ics endpoint."""
+
+    def test_export_ics_success(self, client, db_session, sample_user_data):
+        """Test successful .ics export returns text/calendar content."""
+        user_response = client.post("/register", json=sample_user_data)
+        user_id = user_response.json()["user_id"]
+
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-01-01 09:00",
+            arrival_time="2099-01-01 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+        flight = db_session.query(Flight).first()
+
+        db_session.add(Booking(
+            user_id=user_id,
+            flight_id=flight.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000000
+        ))
+        db_session.commit()
+        booking = db_session.query(Booking).first()
+
+        response = client.get(f"/bookings/{booking.booking_id}/export.ics")
+        assert response.status_code == 200
+        assert "text/calendar" in response.headers["content-type"]
+        body = response.text
+        assert "BEGIN:VCALENDAR" in body
+        assert "BEGIN:VEVENT" in body
+        assert "DTSTART:20990101T090000Z" in body
+        assert "DTEND:20990101T170000Z" in body
+        assert "Earth" in body
+        assert "Mars" in body
+
+    def test_export_ics_not_found(self, client, db_session):
+        """Test .ics export for non-existent booking returns 404."""
+        response = client.get("/bookings/999/export.ics")
+        assert response.status_code == 404

--- a/booking_system_backend/tests/test_services.py
+++ b/booking_system_backend/tests/test_services.py
@@ -973,3 +973,87 @@ class TestFlightFiltering:
 
         results = flight.list_flights(db_session, min_price=10000000)
         assert len(results) == 0
+
+
+class TestGetBookingIcs:
+    """Test get_booking_ics service function."""
+
+    def test_get_booking_ics_success(self, db_session):
+        """Test generating .ics content for a valid booking."""
+        db_session.add(User(name="Test User", email="test@example.com"))
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-01-01 09:00",
+            arrival_time="2099-01-01 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000000
+        ))
+        db_session.commit()
+
+        booking_obj = db_session.query(Booking).first()
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+
+        assert isinstance(result, str)
+        assert "BEGIN:VCALENDAR" in result
+        assert "BEGIN:VEVENT" in result
+        assert "END:VEVENT" in result
+        assert "END:VCALENDAR" in result
+        assert "DTSTART:20990101T090000Z" in result
+        assert "DTEND:20990101T170000Z" in result
+        assert "Earth" in result
+        assert "Mars" in result
+        assert f"booking-{booking_obj.booking_id}@galaxium-travels" in result
+
+    def test_get_booking_ics_booking_not_found(self, db_session):
+        """Test generating .ics for a non-existent booking."""
+        result = booking.get_booking_ics(db_session, 999)
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "BOOKING_NOT_FOUND"
+
+    def test_get_booking_ics_contains_seat_class(self, db_session):
+        """Test that .ics description includes seat class."""
+        db_session.add(User(name="Test User", email="test@example.com"))
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-01-01 09:00",
+            arrival_time="2099-01-01 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="business",
+            price_paid=2500000
+        ))
+        db_session.commit()
+
+        booking_obj = db_session.query(Booking).first()
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+
+        assert isinstance(result, str)
+        assert "business" in result

--- a/booking_system_frontend/src/components/bookings/BookingCard.tsx
+++ b/booking_system_frontend/src/components/bookings/BookingCard.tsx
@@ -4,6 +4,8 @@ import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket } from 'luc
 import { formatDate, formatCurrency } from '../../utils/formatters';
 import { motion } from 'framer-motion';
 
+const API_BASE = import.meta.env.VITE_API_URL || '/api';
+
 interface BookingCardProps {
   booking: Booking;
   flight?: Flight;
@@ -71,6 +73,10 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
   };
 
   const canCancel = booking.status === 'booked';
+
+  const handleAddToCalendar = () => {
+    window.open(`${API_BASE}/bookings/${booking.booking_id}/export.ics`, '_blank');
+  };
 
   return (
     <motion.div
@@ -153,17 +159,28 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
           <span>Booked on {formatDate(booking.booking_time)}</span>
         </div>
 
-        {/* Cancel Button */}
+        {/* Action Buttons */}
         {canCancel && (
-          <Button
-            variant="danger"
-            size="sm"
-            onClick={() => onCancel(booking.booking_id)}
-            isLoading={isCancelling}
-            className="w-full"
-          >
-            Cancel Booking
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleAddToCalendar}
+              className="flex-1 flex items-center justify-center gap-1"
+            >
+              <Calendar size={14} />
+              Add to Calendar
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => onCancel(booking.booking_id)}
+              isLoading={isCancelling}
+              className="flex-1"
+            >
+              Cancel Booking
+            </Button>
+          </div>
         )}
       </Card>
     </motion.div>


### PR DESCRIPTION
# Summary

Adds iCalendar (`.ics`) export functionality for bookings, allowing users to add their flight bookings directly to any calendar application. This feature is exposed via a new REST API endpoint, a new MCP tool, and a frontend "Add to Calendar" button on each booking card.

# Files Changed

📄 `booking_system_backend/services/booking.py`

Introduces the `get_booking_ics` service function, which generates a valid iCalendar (`.ics`) formatted string for a given booking. The function queries the booking and its associated flight from the database, formats the departure and arrival times into the iCal datetime format, and assembles a `VCALENDAR`/`VEVENT` block with relevant details such as origin, destination, seat class, and price paid. Returns an `ErrorResponse` if the booking or flight is not found. Also adds `timezone` to the `datetime` import for completeness.

📄 `booking_system_backend/server.py`

Wires up the new `.ics` export feature in two places:
- **MCP tool** (`get_booking_ics`): Exposes the service function as an MCP tool, raising an exception on error to surface issues to the AI agent.
- **REST endpoint** (`GET /bookings/{booking_id}/export.ics`): Returns the `.ics` content as a `text/calendar` file attachment using FastAPI's `Response`, prompting a file download named `booking-{id}.ics`. Also imports `fastapi.responses.Response` to support the binary/text response type.

📄 `booking_system_backend/tests/test_services.py`

Adds the `TestGetBookingIcs` test class covering the `get_booking_ics` service function with three test cases:
- **Success**: Verifies that a valid booking produces a well-formed `.ics` string containing the correct `DTSTART`, `DTEND`, origin, destination, and UID.
- **Booking not found**: Verifies that an `ErrorResponse` with `BOOKING_NOT_FOUND` is returned for a non-existent booking ID.
- **Seat class in description**: Verifies that the booking's seat class is included in the generated `.ics` description.

📄 `booking_system_backend/tests/test_rest.py`

Adds the `TestExportBookingIcs` test class covering the `GET /bookings/{booking_id}/export.ics` REST endpoint with two test cases:
- **Success**: Creates a user, flight, and booking, then verifies the endpoint returns HTTP 200 with `text/calendar` content type and a valid `.ics` body containing expected fields.
- **Not found**: Verifies that a request for a non-existent booking ID returns HTTP 404.

📄 `booking_system_frontend/src/components/bookings/BookingCard.tsx`

Updates the `BookingCard` component to add an "Add to Calendar" button alongside the existing "Cancel Booking" button. A `handleAddToCalendar` handler opens the new `.ics` export endpoint URL in a new browser tab, triggering a calendar file download. The action buttons are arranged in a flex row, with the calendar button using the `Calendar` icon from `lucide-react`. The `API_BASE` URL is read from the `VITE_API_URL` environment variable with a fallback to `/api`.