### PR TITLE
feat: add ICS calendar export for bookings

### DIFF
--- a/.bob/custom_modes.yaml
+++ b/.bob/custom_modes.yaml
@@ -1,47 +1,47 @@
-# customModes:
-#   - slug: code-reviewer
-#     name: Code Reviewer
-#     roleDefinition: >-
-#       You are a strict, read-only code reviewer. Your job is to read code and
-#       provide clear, actionable feedback on quality: naming conventions, code
-#       structure, consistency with project style, obvious bugs, dead code, and
-#       anything that would make the code harder to maintain or understand.
+customModes:
+  - slug: code-reviewer
+    name: Code Reviewer
+    roleDefinition: >-
+      You are a strict, read-only code reviewer. Your job is to read code and
+      provide clear, actionable feedback on quality: naming conventions, code
+      structure, consistency with project style, obvious bugs, dead code, and
+      anything that would make the code harder to maintain or understand.
 
-#       You never edit or create files. You never run the application. You may run
-#       linters and test suites to gather evidence, but only to inform your review.
+      You never edit or create files. You never run the application. You may run
+      linters and test suites to gather evidence, but only to inform your review.
 
-#       Your output is always a structured review: a short summary of findings,
-#       followed by specific issues with file references and line numbers where
-#       relevant. Distinguish between blocking issues (must fix) and suggestions
-#       (nice to have). Be direct and precise - do not pad feedback with praise.
-#     whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
-#     description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#   - slug: deploy-engineer
-#     name: Deploy Engineer
-#     roleDefinition: >-
-#       You are a Deploy Engineer. Your sole responsibility is making sure this
-#       project deploys correctly and reliably. You are an expert in the deployment
-#       scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
-#       infrastructure-as-code in this project.
+      Your output is always a structured review: a short summary of findings,
+      followed by specific issues with file references and line numbers where
+      relevant. Distinguish between blocking issues (must fix) and suggestions
+      (nice to have). Be direct and precise - do not pad feedback with praise.
+    whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
+    description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
+    groups:
+      - read
+      - execute
+      - skill
+  - slug: deploy-engineer
+    name: Deploy Engineer
+    roleDefinition: >-
+      You are a Deploy Engineer. Your sole responsibility is making sure this
+      project deploys correctly and reliably. You are an expert in the deployment
+      scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
+      infrastructure-as-code in this project.
 
-#       You only read and edit files inside the scripts/ directory. You do not
-#       touch application source code, frontend assets, or test files. If a
-#       deployment problem traces back to application code, you report it clearly
-#       but do not fix it yourself.
+      You only read and edit files inside the scripts/ directory. You do not
+      touch application source code, frontend assets, or test files. If a
+      deployment problem traces back to application code, you report it clearly
+      but do not fix it yourself.
 
-#       When reviewing or editing deploy scripts, you check for: missing error
-#       handling, hardcoded secrets or environment assumptions, non-idempotent
-#       operations, missing health checks, and steps that could cause downtime.
-#       You run commands to validate and test deploy scripts where possible.
-#     whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
-#     description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#       - - edit
-#         - fileRegex: "scripts/.*"
+      When reviewing or editing deploy scripts, you check for: missing error
+      handling, hardcoded secrets or environment assumptions, non-idempotent
+      operations, missing health checks, and steps that could cause downtime.
+      You run commands to validate and test deploy scripts where possible.
+    whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
+    description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
+    groups:
+      - read
+      - execute
+      - skill
+      - - edit
+        - fileRegex: "scripts/.*"

--- a/booking_system_backend/server.py
+++ b/booking_system_backend/server.py
@@ -1,6 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import Response
 from fastmcp import FastMCP
 from sqlalchemy.orm import Session
 from typing import Union, Optional
@@ -83,6 +84,20 @@ def register_user(name: str, email: str) -> UserOut:
     db = SessionLocal()
     try:
         result = user.register_user(db, name, email)
+        if isinstance(result, ErrorResponse):
+            raise Exception(result.details or result.error)
+        return result
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def get_booking_ics(booking_id: int) -> str:
+    """Export a booking as an ICS calendar file string.
+    Returns a VCALENDAR text (RFC 5545) for the booking, or raises an error if not found."""
+    db = SessionLocal()
+    try:
+        result = booking.get_booking_ics(db, booking_id)
         if isinstance(result, ErrorResponse):
             raise Exception(result.details or result.error)
         return result
@@ -248,6 +263,22 @@ def book_flight_endpoint(request: BookingRequest, db: Session = Depends(get_db))
 def get_user_bookings(user_id: int, db: Session = Depends(get_db)):
     """Retrieve all bookings for a specific user by user_id."""
     return booking.get_bookings(db, user_id)
+
+
+@app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
+def export_booking_ics(booking_id: int, db: Session = Depends(get_db)):
+    """Export a booking as an ICS calendar file.
+
+    Returns a text/calendar file with Content-Disposition: attachment.
+    """
+    result = booking.get_booking_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.model_dump())
+    return Response(
+        content=result,
+        media_type="text/calendar",
+        headers={"Content-Disposition": f"attachment; filename=\"booking-{booking_id}.ics\""},
+    )
 
 
 @app.post("/cancel/{booking_id}", response_model=Union[BookingOut, ErrorResponse], tags=["Bookings"])

--- a/booking_system_backend/services/booking.py
+++ b/booking_system_backend/services/booking.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 from datetime import datetime
 from models import User, Flight, Booking
 from schemas import BookingOut, ErrorResponse, SeatClass
+import uuid
 
 
 # Price multipliers for each seat class
@@ -126,3 +127,51 @@ def get_bookings(db: Session, user_id: int) -> list[BookingOut]:
     """Retrieve all bookings for a specific user."""
     bookings = db.query(Booking).filter(Booking.user_id == user_id).all()
     return [BookingOut.model_validate(b) for b in bookings]
+
+
+def _format_ics_datetime(dt_str: str) -> str:
+    """Normalise stored datetime strings to ICS YYYYMMDDTHHMMSSZ format.
+
+    Handles both space-separated ('2099-01-01 09:00') and ISO 8601
+    ('2099-01-01T09:00:00Z') formats.  All times are treated as UTC.
+    """
+    # Strip trailing Z so fromisoformat() can parse it, then replace space with T
+    normalised = dt_str.rstrip('Z').replace(' ', 'T')
+    dt = datetime.fromisoformat(normalised)
+    return dt.strftime('%Y%m%dT%H%M%SZ')
+
+
+def get_booking_ics(db: Session, booking_id: int) -> str | ErrorResponse:
+    """Return an RFC 5545 VCALENDAR string for a booking, or ErrorResponse if not found."""
+    booking = db.query(Booking).filter(Booking.booking_id == booking_id).first()
+    if not booking:
+        return ErrorResponse(
+            error="Booking not found",
+            error_code="BOOKING_NOT_FOUND",
+            details=f"Booking with ID {booking_id} not found."
+        )
+
+    flight = db.query(Flight).filter(Flight.flight_id == booking.flight_id).first()
+    origin = flight.origin if flight else "Unknown"
+    destination = flight.destination if flight else "Unknown"
+    departure = _format_ics_datetime(flight.departure_time) if flight else "19700101T000000Z"
+    arrival = _format_ics_datetime(flight.arrival_time) if flight else "19700101T000000Z"
+
+    dtstamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+    uid = str(uuid.uuid4())
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Galaxium Travels//Booking Export//EN",
+        "BEGIN:VEVENT",
+        f"UID:{uid}",
+        f"DTSTAMP:{dtstamp}",
+        f"DTSTART:{departure}",
+        f"DTEND:{arrival}",
+        f"SUMMARY:Galaxium Flight {origin} → {destination}",
+        f"DESCRIPTION:Booking #{booking_id} · {booking.seat_class.capitalize()} class · {origin} to {destination}",
+        "END:VEVENT",
+        "END:VCALENDAR",
+    ]
+    return "\r\n".join(lines) + "\r\n"

--- a/booking_system_backend/tests/test_rest.py
+++ b/booking_system_backend/tests/test_rest.py
@@ -870,3 +870,54 @@ class TestFlightsEndpointFiltering:
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 2
+
+
+class TestIcsEndpoint:
+    """Test GET /bookings/{booking_id}/export.ics endpoint."""
+
+    def test_export_ics_success(self, client, db_session, sample_user_data):
+        """Test that a valid booking returns HTTP 200 with text/calendar content type."""
+        # Register user
+        user_response = client.post("/register", json=sample_user_data)
+        user_id = user_response.json()["user_id"]
+
+        # Create flight
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-01-01 09:00",
+            arrival_time="2099-01-01 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+        flight_obj = db_session.query(Flight).first()
+
+        # Create booking
+        from models import Booking
+        db_session.add(Booking(
+            user_id=user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-01-01 08:00",
+            seat_class="economy",
+            price_paid=1000000
+        ))
+        db_session.commit()
+        from models import Booking as BookingModel
+        booking_obj = db_session.query(BookingModel).first()
+
+        response = client.get(f"/bookings/{booking_obj.booking_id}/export.ics")
+
+        assert response.status_code == 200
+        assert "text/calendar" in response.headers["content-type"]
+        assert "BEGIN:VCALENDAR" in response.text
+        assert "BEGIN:VEVENT" in response.text
+
+    def test_export_ics_not_found(self, client, db_session):
+        """Test that a missing booking returns HTTP 404."""
+        response = client.get("/bookings/99999/export.ics")
+
+        assert response.status_code == 404

--- a/booking_system_backend/tests/test_services.py
+++ b/booking_system_backend/tests/test_services.py
@@ -973,3 +973,96 @@ class TestFlightFiltering:
 
         results = flight.list_flights(db_session, min_price=10000000)
         assert len(results) == 0
+
+
+class TestBookingIcsService:
+    """Test get_booking_ics service function."""
+
+    def test_get_booking_ics_valid(self, db_session):
+        """Test that a valid booking returns a properly formatted ICS string."""
+        from models import User, Flight, Booking
+
+        db_session.add(User(name="Test User", email="test@example.com"))
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-01-01 09:00",
+            arrival_time="2099-01-01 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-01-01 08:00",
+            seat_class="economy",
+            price_paid=1000000
+        ))
+        db_session.commit()
+        booking_obj = db_session.query(Booking).first()
+
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+
+        assert isinstance(result, str)
+        assert "BEGIN:VCALENDAR" in result
+        assert "BEGIN:VEVENT" in result
+        assert "END:VEVENT" in result
+        assert "END:VCALENDAR" in result
+        assert "DTSTART:20990101T090000Z" in result
+        assert "DTEND:20990101T170000Z" in result
+        assert "Earth" in result
+        assert "Mars" in result
+        # ICS requires CRLF line endings
+        assert "\r\n" in result
+
+    def test_get_booking_ics_not_found(self, db_session):
+        """Test that a missing booking returns ErrorResponse."""
+        from schemas import ErrorResponse
+
+        result = booking.get_booking_ics(db_session, 99999)
+
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "BOOKING_NOT_FOUND"
+
+    def test_get_booking_ics_iso_datetime_format(self, db_session):
+        """Test that ISO 8601 datetime format (with T and Z) is also handled correctly."""
+        from models import User, Flight, Booking
+
+        db_session.add(User(name="ISO User", email="iso@example.com"))
+        db_session.add(Flight(
+            origin="Moon",
+            destination="Jupiter",
+            departure_time="2099-06-15T12:30:00Z",
+            arrival_time="2099-06-16T08:00:00Z",
+            base_price=2000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-06-01T10:00:00Z",
+            seat_class="business",
+            price_paid=5000000
+        ))
+        db_session.commit()
+        booking_obj = db_session.query(Booking).first()
+
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+
+        assert isinstance(result, str)
+        assert "DTSTART:20990615T123000Z" in result
+        assert "DTEND:20990616T080000Z" in result

--- a/booking_system_frontend/src/components/bookings/BookingCard.tsx
+++ b/booking_system_frontend/src/components/bookings/BookingCard.tsx
@@ -1,8 +1,10 @@
 import type { Booking, Flight } from '../../types';
 import { Card, Button } from '../common';
-import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket } from 'lucide-react';
+import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket, CalendarPlus } from 'lucide-react';
 import { formatDate, formatCurrency } from '../../utils/formatters';
 import { motion } from 'framer-motion';
+
+const API_BASE = import.meta.env.VITE_API_URL || '/api';
 
 interface BookingCardProps {
   booking: Booking;
@@ -71,6 +73,14 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
   };
 
   const canCancel = booking.status === 'booked';
+
+  const handleAddToCalendar = () => {
+    const url = `${API_BASE}/bookings/${booking.booking_id}/export.ics`;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `booking-${booking.booking_id}.ics`;
+    a.click();
+  };
 
   return (
     <motion.div
@@ -153,18 +163,31 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
           <span>Booked on {formatDate(booking.booking_time)}</span>
         </div>
 
-        {/* Cancel Button */}
-        {canCancel && (
-          <Button
-            variant="danger"
-            size="sm"
-            onClick={() => onCancel(booking.booking_id)}
-            isLoading={isCancelling}
-            className="w-full"
-          >
-            Cancel Booking
-          </Button>
-        )}
+        {/* Action Buttons */}
+        <div className="flex gap-2">
+          {canCancel && (
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => onCancel(booking.booking_id)}
+              isLoading={isCancelling}
+              className="flex-1"
+            >
+              Cancel Booking
+            </Button>
+          )}
+          {canCancel && (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleAddToCalendar}
+              className="flex-1"
+            >
+              <CalendarPlus size={16} className="mr-1" />
+              Add to Calendar
+            </Button>
+          )}
+        </div>
       </Card>
     </motion.div>
   );


### PR DESCRIPTION
# Summary

This pull request adds ICS (iCalendar) export functionality to the Galaxium Travels booking system, allowing users to download their flight bookings as `.ics` calendar files. The feature is exposed through a new REST endpoint, an MCP tool, and a frontend "Add to Calendar" button on each booking card. Supporting unit and integration tests are included, and a previously commented-out AI custom modes configuration is activated.

# Files Changed

📄 `.bob/custom_modes.yaml`

Uncomments the entire custom AI modes configuration, activating two previously disabled modes: a read-only **Code Reviewer** and a deployment-scoped **Deploy Engineer**. No logic was changed — only the comment characters were removed to enable both modes.

---

📄 `booking_system_backend/server.py`

Adds two new endpoints/tools for ICS export:
- A new **MCP tool** `get_booking_ics` that calls the booking service and returns the raw VCALENDAR string, raising an exception on error.
- A new **REST endpoint** `GET /bookings/{booking_id}/export.ics` that returns the ICS data as a `text/calendar` file with a `Content-Disposition: attachment` header, responding with HTTP 404 if the booking is not found.
Also imports `fastapi.responses.Response` to support the binary/text calendar response.

---

📄 `booking_system_backend/services/booking.py`

Implements the core ICS generation logic:
- Adds a private helper `_format_ics_datetime` that normalises both space-separated and ISO 8601 datetime strings into the RFC 5545 `YYYYMMDDTHHMMSSZ` format.
- Adds `get_booking_ics`, which queries the booking and associated flight, builds a valid RFC 5545 `VCALENDAR`/`VEVENT` block with proper CRLF line endings, and returns it as a string — or returns an `ErrorResponse` if the booking is not found.
Also imports `uuid` for generating unique `UID` fields per calendar event.

---

📄 `booking_system_backend/tests/test_rest.py`

Adds a new `TestIcsEndpoint` test class with two test cases:
- `test_export_ics_success`: Creates a user, flight, and booking, then asserts the endpoint returns HTTP 200 with `text/calendar` content type and a valid ICS body containing `BEGIN:VCALENDAR` and `BEGIN:VEVENT`.
- `test_export_ics_not_found`: Asserts that requesting an ICS for a non-existent booking ID returns HTTP 404.

---

📄 `booking_system_backend/tests/test_services.py`

Adds a new `TestBookingIcsService` test class with three test cases:
- `test_get_booking_ics_valid`: Verifies that the service returns a correctly formatted ICS string including expected `DTSTART`/`DTEND` values, origin/destination, and CRLF line endings.
- `test_get_booking_ics_not_found`: Verifies that a missing booking ID returns an `ErrorResponse` with error code `BOOKING_NOT_FOUND`.
- `test_get_booking_ics_iso_datetime_format`: Verifies that flight times stored in ISO 8601 format (with `T` and `Z`) are also parsed and formatted correctly.

---

📄 `booking_system_frontend/src/components/bookings/BookingCard.tsx`

Updates the `BookingCard` component to surface the ICS export feature in the UI:
- Adds a `CalendarPlus` icon import from `lucide-react`.
- Reads the API base URL from the `VITE_API_URL` environment variable (falling back to `/api`).
- Implements a `handleAddToCalendar` click handler that programmatically triggers a download of the `.ics` file via a dynamically created anchor element.
- Refactors the action button area from a single "Cancel Booking" button to a flex row containing both "Cancel Booking" and a new "Add to Calendar" button, both visible when the booking status is `booked`.