### PR TITLE
feat: add ICS calendar export for bookings (#44)

### DIFF
--- a/.bob/custom_modes.yaml
+++ b/.bob/custom_modes.yaml
@@ -1,47 +1,47 @@
-# customModes:
-#   - slug: code-reviewer
-#     name: Code Reviewer
-#     roleDefinition: >-
-#       You are a strict, read-only code reviewer. Your job is to read code and
-#       provide clear, actionable feedback on quality: naming conventions, code
-#       structure, consistency with project style, obvious bugs, dead code, and
-#       anything that would make the code harder to maintain or understand.
+customModes:
+  - slug: code-reviewer
+    name: Code Reviewer
+    roleDefinition: >-
+      You are a strict, read-only code reviewer. Your job is to read code and
+      provide clear, actionable feedback on quality: naming conventions, code
+      structure, consistency with project style, obvious bugs, dead code, and
+      anything that would make the code harder to maintain or understand.
 
-#       You never edit or create files. You never run the application. You may run
-#       linters and test suites to gather evidence, but only to inform your review.
+      You never edit or create files. You never run the application. You may run
+      linters and test suites to gather evidence, but only to inform your review.
 
-#       Your output is always a structured review: a short summary of findings,
-#       followed by specific issues with file references and line numbers where
-#       relevant. Distinguish between blocking issues (must fix) and suggestions
-#       (nice to have). Be direct and precise - do not pad feedback with praise.
-#     whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
-#     description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#   - slug: deploy-engineer
-#     name: Deploy Engineer
-#     roleDefinition: >-
-#       You are a Deploy Engineer. Your sole responsibility is making sure this
-#       project deploys correctly and reliably. You are an expert in the deployment
-#       scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
-#       infrastructure-as-code in this project.
+      Your output is always a structured review: a short summary of findings,
+      followed by specific issues with file references and line numbers where
+      relevant. Distinguish between blocking issues (must fix) and suggestions
+      (nice to have). Be direct and precise - do not pad feedback with praise.
+    whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
+    description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
+    groups:
+      - read
+      - execute
+      - skill
+  - slug: deploy-engineer
+    name: Deploy Engineer
+    roleDefinition: >-
+      You are a Deploy Engineer. Your sole responsibility is making sure this
+      project deploys correctly and reliably. You are an expert in the deployment
+      scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
+      infrastructure-as-code in this project.
 
-#       You only read and edit files inside the scripts/ directory. You do not
-#       touch application source code, frontend assets, or test files. If a
-#       deployment problem traces back to application code, you report it clearly
-#       but do not fix it yourself.
+      You only read and edit files inside the scripts/ directory. You do not
+      touch application source code, frontend assets, or test files. If a
+      deployment problem traces back to application code, you report it clearly
+      but do not fix it yourself.
 
-#       When reviewing or editing deploy scripts, you check for: missing error
-#       handling, hardcoded secrets or environment assumptions, non-idempotent
-#       operations, missing health checks, and steps that could cause downtime.
-#       You run commands to validate and test deploy scripts where possible.
-#     whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
-#     description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#       - - edit
-#         - fileRegex: "scripts/.*"
+      When reviewing or editing deploy scripts, you check for: missing error
+      handling, hardcoded secrets or environment assumptions, non-idempotent
+      operations, missing health checks, and steps that could cause downtime.
+      You run commands to validate and test deploy scripts where possible.
+    whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
+    description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
+    groups:
+      - read
+      - execute
+      - skill
+      - - edit
+        - fileRegex: "scripts/.*"

--- a/booking_system_backend/server.py
+++ b/booking_system_backend/server.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.responses import Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastmcp import FastMCP
 from sqlalchemy.orm import Session
@@ -69,6 +70,20 @@ def cancel_booking(booking_id: int) -> BookingOut:
     db = SessionLocal()
     try:
         result = booking.cancel_booking(db, booking_id)
+        if isinstance(result, ErrorResponse):
+            raise Exception(result.details or result.error)
+        return result
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def export_booking_ics(booking_id: int) -> str:
+    """Export a booking as an RFC 5545-compliant .ics calendar event string.
+    Returns the ICS content as a string, or raises an error if the booking is not found."""
+    db = SessionLocal()
+    try:
+        result = booking.get_booking_ics(db, booking_id)
         if isinstance(result, ErrorResponse):
             raise Exception(result.details or result.error)
         return result
@@ -257,6 +272,21 @@ def cancel_booking_endpoint(booking_id: int, db: Session = Depends(get_db)):
     Increments available seats for the flight if successful.
     """
     return booking.cancel_booking(db, booking_id)
+
+
+@app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
+def export_booking_ics_endpoint(booking_id: int, db: Session = Depends(get_db)):
+    """Export a booking as an RFC 5545-compliant .ics calendar file."""
+    result = booking.get_booking_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.model_dump())
+    return Response(
+        content=result,
+        media_type="text/calendar",
+        headers={
+            "Content-Disposition": f'attachment; filename="booking-{booking_id}.ics"'
+        },
+    )
 
 
 @app.post("/register", response_model=Union[UserOut, ErrorResponse], tags=["Users"])

--- a/booking_system_backend/services/booking.py
+++ b/booking_system_backend/services/booking.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import Session
-from datetime import datetime
+from datetime import datetime, timezone
 from models import User, Flight, Booking
 from schemas import BookingOut, ErrorResponse, SeatClass
 
@@ -126,3 +126,53 @@ def get_bookings(db: Session, user_id: int) -> list[BookingOut]:
     """Retrieve all bookings for a specific user."""
     bookings = db.query(Booking).filter(Booking.user_id == user_id).all()
     return [BookingOut.model_validate(b) for b in bookings]
+
+
+def get_booking_ics(db: Session, booking_id: int) -> str | ErrorResponse:
+    """Generate an RFC 5545-compliant .ics calendar event for a booking."""
+    booking = db.query(Booking).filter(Booking.booking_id == booking_id).first()
+    if not booking:
+        return ErrorResponse(
+            error="Booking not found",
+            error_code="BOOKING_NOT_FOUND",
+            details=f"Booking with ID {booking_id} not found."
+        )
+
+    flight = db.query(Flight).filter(Flight.flight_id == booking.flight_id).first()
+    if not flight:
+        return ErrorResponse(
+            error="Flight not found",
+            error_code="FLIGHT_NOT_FOUND",
+            details=f"Flight with ID {booking.flight_id} not found."
+        )
+
+    fmt = "%Y-%m-%d %H:%M"
+    dtstart = datetime.strptime(flight.departure_time, fmt).strftime("%Y%m%dT%H%M%SZ")
+    dtend = datetime.strptime(flight.arrival_time, fmt).strftime("%Y%m%dT%H%M%SZ")
+    dtstamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    uid = f"booking-{booking.booking_id}@galaxium-travels"
+
+    seat_label = {
+        'economy': 'Economy',
+        'business': 'Business',
+        'galaxium': 'Galaxium Class',
+    }.get(booking.seat_class, booking.seat_class)
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Galaxium Travels//Booking System//EN",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+        "BEGIN:VEVENT",
+        f"UID:{uid}",
+        f"DTSTAMP:{dtstamp}",
+        f"DTSTART:{dtstart}",
+        f"DTEND:{dtend}",
+        f"SUMMARY:Galaxium Travels – {flight.origin} to {flight.destination}",
+        f"DESCRIPTION:Booking #{booking.booking_id}\\nFlight #{flight.flight_id}\\nSeat class: {seat_label}\\nStatus: {booking.status}",
+        f"LOCATION:{flight.origin} to {flight.destination}",
+        "END:VEVENT",
+        "END:VCALENDAR",
+    ]
+    return "\r\n".join(lines) + "\r\n"

--- a/booking_system_backend/tests/test_rest.py
+++ b/booking_system_backend/tests/test_rest.py
@@ -870,3 +870,52 @@ class TestFlightsEndpointFiltering:
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 2
+
+
+class TestBookingIcsEndpoint:
+    """Test GET /bookings/{booking_id}/export.ics endpoint."""
+
+    def _create_booking(self, client, db_session, sample_user_data):
+        """Helper: register a user, create a flight + booking; return booking_id."""
+        user_resp = client.post("/register", json=sample_user_data)
+        user_id = user_resp.json()["user_id"]
+
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-06-01 10:00",
+            arrival_time="2099-06-01 18:00",
+            base_price=500000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1,
+        ))
+        db_session.commit()
+        flight = db_session.query(Flight).first()
+
+        db_session.add(Booking(
+            user_id=user_id,
+            flight_id=flight.flight_id,
+            status="booked",
+            booking_time="2099-01-01 08:00",
+            seat_class="economy",
+            price_paid=500000,
+        ))
+        db_session.commit()
+        booking = db_session.query(Booking).first()
+        return booking.booking_id
+
+    def test_export_ics_200_with_correct_headers(self, client, db_session, sample_user_data):
+        """Valid booking returns 200 with text/calendar content-type and attachment header."""
+        booking_id = self._create_booking(client, db_session, sample_user_data)
+        response = client.get(f"/bookings/{booking_id}/export.ics")
+
+        assert response.status_code == 200
+        assert "text/calendar" in response.headers["content-type"]
+        assert f"booking-{booking_id}.ics" in response.headers["content-disposition"]
+        assert response.text.startswith("BEGIN:VCALENDAR")
+
+    def test_export_ics_404_for_unknown_id(self, client, db_session):
+        """Unknown booking_id returns 404."""
+        response = client.get("/bookings/99999/export.ics")
+        assert response.status_code == 404

--- a/booking_system_backend/tests/test_services.py
+++ b/booking_system_backend/tests/test_services.py
@@ -973,3 +973,64 @@ class TestFlightFiltering:
 
         results = flight.list_flights(db_session, min_price=10000000)
         assert len(results) == 0
+
+
+class TestBookingIcsService:
+    """Test get_booking_ics service function."""
+
+    def _make_booking(self, db_session):
+        """Helper: create a user, flight, and booking; return (booking_obj, flight_obj)."""
+        db_session.add(User(name="Ics User", email="ics@example.com"))
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-06-01 10:00",
+            arrival_time="2099-06-01 18:00",
+            base_price=500000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1,
+        ))
+        db_session.commit()
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+        from models import Booking
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-01-01 08:00",
+            seat_class="economy",
+            price_paid=500000,
+        ))
+        db_session.commit()
+        booking_obj = db_session.query(Booking).first()
+        return booking_obj, flight_obj
+
+    def test_valid_booking_returns_ics_string(self, db_session):
+        """Valid booking returns a str starting with BEGIN:VCALENDAR."""
+        booking_obj, _ = self._make_booking(db_session)
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+        assert isinstance(result, str)
+        assert result.startswith("BEGIN:VCALENDAR")
+
+    def test_ics_contains_required_fields(self, db_session):
+        """ICS output contains all required RFC 5545 fields."""
+        booking_obj, flight_obj = self._make_booking(db_session)
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+        assert isinstance(result, str)
+        assert "BEGIN:VEVENT" in result
+        assert "END:VEVENT" in result
+        assert "END:VCALENDAR" in result
+        assert "DTSTART:" in result
+        assert "DTEND:" in result
+        assert "SUMMARY:" in result
+        assert flight_obj.origin in result
+        assert flight_obj.destination in result
+
+    def test_not_found_returns_error_response(self, db_session):
+        """Non-existent booking_id returns ErrorResponse."""
+        from schemas import ErrorResponse
+        result = booking.get_booking_ics(db_session, 99999)
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "BOOKING_NOT_FOUND"

--- a/booking_system_frontend/src/components/bookings/BookingCard.tsx
+++ b/booking_system_frontend/src/components/bookings/BookingCard.tsx
@@ -1,6 +1,6 @@
 import type { Booking, Flight } from '../../types';
 import { Card, Button } from '../common';
-import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket } from 'lucide-react';
+import { Plane, Calendar, CheckCircle, XCircle, Clock, Crown, Rocket, CalendarPlus } from 'lucide-react';
 import { formatDate, formatCurrency } from '../../utils/formatters';
 import { motion } from 'framer-motion';
 
@@ -71,6 +71,7 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
   };
 
   const canCancel = booking.status === 'booked';
+  const canExport = booking.status !== 'cancelled';
 
   return (
     <motion.div
@@ -153,18 +154,36 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
           <span>Booked on {formatDate(booking.booking_time)}</span>
         </div>
 
-        {/* Cancel Button */}
-        {canCancel && (
-          <Button
-            variant="danger"
-            size="sm"
-            onClick={() => onCancel(booking.booking_id)}
-            isLoading={isCancelling}
-            className="w-full"
-          >
-            Cancel Booking
-          </Button>
-        )}
+        {/* Action Buttons */}
+        <div className={canCancel ? "flex gap-2" : ""}>
+          {canExport && (
+            <a
+              href={`/api/bookings/${booking.booking_id}/export.ics`}
+              download={`booking-${booking.booking_id}.ics`}
+              className="flex-1"
+            >
+              <Button
+                variant="secondary"
+                size="sm"
+                className="w-full"
+              >
+                <CalendarPlus size={16} />
+                Add to Calendar
+              </Button>
+            </a>
+          )}
+          {canCancel && (
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => onCancel(booking.booking_id)}
+              isLoading={isCancelling}
+              className="flex-1"
+            >
+              Cancel Booking
+            </Button>
+          )}
+        </div>
       </Card>
     </motion.div>
   );

--- a/docs/plans/issue-44-ics-export-reviewed.md
+++ b/docs/plans/issue-44-ics-export-reviewed.md
@@ -1,0 +1,34 @@
+# Issue #44 — Calendar Export (.ics) for Bookings — Reviewed Plan
+
+**Status:** Draft · Reviewed  
+**Branch:** `feature/44-ics-export`  
+**Est.:** ~1 hour
+
+## Summary
+
+The ICS export plan is solid and ready to implement with three targeted amendments: the "Add to Calendar" button will appear on all non-cancelled bookings (independent of the Cancel button gate), the frontend download handler will use the simpler direct `<a href>` approach since the nginx proxy handles routing correctly in production, and the ICS body will use RFC 5545-compliant `\r\n` line endings throughout for enterprise calendar client compatibility.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Frontend button gate | `booking.status !== 'cancelled'` — independent of the Cancel button | Completed trips are still valid calendar events worth exporting; tying it to `canCancel` would silently hide it for `'completed'` bookings |
+| ICS download handler | Direct `<a href>` approach (no fetch/blob) | Simpler code; nginx proxy in production correctly routes `/api` to the backend, so same-origin `Content-Disposition` restrictions don't apply |
+| ICS line endings | `\r\n` (RFC 5545-compliant) | Two-character swap; keeps the output valid for enterprise clients (Exchange, Outlook) in addition to the stated AC targets (Apple Calendar, Google Calendar) |
+
+## Open Items
+
+- The plan notes "file opens correctly in Apple Calendar and Google Calendar" as an AC item — manual verification required post-implementation; automated tests cannot assert this.
+- `\r\n` throughout means the Python unit test assertions should use `assertIn("BEGIN:VCALENDAR", result)` — test must not split on `\n` alone or it will fail on Windows-style content.
+- Confirm that the nginx `location /api/` block in the Docker image forwards all response headers (including `Content-Disposition`) without stripping them; worth a one-off manual curl smoke test in Docker.
+
+## Next Steps
+
+1. Add `get_booking_ics()` to `booking_system_backend/services/booking.py` — use `\r\n` as the ICS line separator; parse flight times with `datetime.strptime(t, "%Y-%m-%d %H:%M")`.
+2. Add REST endpoint `GET /bookings/{id}/export.ics` to `server.py` — import `Response` from `fastapi.responses`; return `text/calendar` with `Content-Disposition: attachment`.
+3. Add matching MCP tool `export_booking_ics(booking_id: int)` to `server.py` — follow the `SessionLocal` / `db.close()` pattern used by existing MCP tools.
+4. Update `BookingCard.tsx` — add `canExport = booking.status !== 'cancelled'` gate; render "Add to Calendar" button using `variant="secondary"` + `CalendarPlus` icon from `lucide-react`; use direct `<a href>` download handler.
+5. Add `TestBookingIcsService` to `test_services.py` — three cases: valid returns `str` starting with `BEGIN:VCALENDAR`, contains required fields, not-found returns `ErrorResponse`.
+6. Add `TestBookingIcsEndpoint` to `test_rest.py` — two cases: 200 with correct headers, 404 for unknown ID.
+7. Run `cd booking_system_backend && pytest` — all tests must pass.
+8. Run `cd booking_system_frontend && npm run lint` — no new lint errors.

--- a/docs/plans/issue-44-ics-export.md
+++ b/docs/plans/issue-44-ics-export.md
@@ -1,0 +1,177 @@
+# Issue #44 — Calendar Export (.ics) for Bookings
+
+**Labels:** area/fullstack · enhancement · roadmap · tier-3  
+**Est.:** ~1 hour  
+**Branch:** `feature/44-ics-export`
+
+## Overview
+
+Add `GET /bookings/{id}/export.ics` to the Python backend and an **"Add to Calendar"** download button inside `BookingCard.tsx`, gated on `status === 'booked'`. No third-party libraries needed on either side.
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `booking_system_backend/services/booking.py` | New `get_booking_ics()` service function |
+| `booking_system_backend/server.py` | New REST endpoint + matching MCP tool |
+| `booking_system_backend/tests/test_services.py` | Unit tests for the service function |
+| `booking_system_backend/tests/test_rest.py` | REST tests for 200/404 responses |
+| `booking_system_frontend/src/components/bookings/BookingCard.tsx` | "Add to Calendar" button + download handler |
+
+## Implementation Steps
+
+### Step 1 — Backend: Add `get_booking_ics()` service function
+**File:** `booking_system_backend/services/booking.py`
+
+Add a new function that takes `db` and `booking_id`. It queries `Booking` joined with `Flight` (same pattern as `cancel_booking()` which already does `db.query(Flight).filter(Flight.flight_id == booking.flight_id).first()`), and returns either an `ErrorResponse` (booking not found) or a `str` containing the iCalendar payload.
+
+The iCalendar text is built via plain string formatting — no library needed (RFC 5545):
+
+```
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Galaxium Travels//Booking System//EN
+BEGIN:VEVENT
+UID:booking-{booking_id}@galaxium-travels
+DTSTAMP:{now_utc formatted as YYYYMMDDTHHmmssZ}
+DTSTART:{flight.departure_time formatted as YYYYMMDDTHHmmssZ}
+DTEND:{flight.arrival_time formatted as YYYYMMDDTHHmmssZ}
+SUMMARY:Galaxium Flight {flight.flight_id} – {origin} to {destination}
+LOCATION:{origin} → {destination}
+DESCRIPTION:Booking #{booking_id}\nSeat class: {seat_class}\nPrice: {price_paid} credits
+END:VEVENT
+END:VCALENDAR
+```
+
+> **Date parsing:** Flight times are stored as `"2099-01-01 09:00"` strings (`models.py`). Parse with `datetime.strptime(t, "%Y-%m-%d %H:%M")` and format to iCal with `strftime("%Y%m%dT%H%M%SZ")`. Treat all times as UTC (consistent with the ISO 8601 seed data note in the issue).
+
+Return type: `str | ErrorResponse` — consistent with the existing pattern in this module.
+
+---
+
+### Step 2 — Backend: Add REST endpoint in `server.py`
+**File:** `booking_system_backend/server.py` (after the existing bookings endpoints, ~line 260)
+
+```python
+from fastapi.responses import Response
+
+@app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
+def export_booking_ics(booking_id: int, db: Session = Depends(get_db)):
+    """Export a booking as an iCalendar (.ics) file."""
+    result = booking.get_booking_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.model_dump())
+    return Response(
+        content=result,
+        media_type="text/calendar",
+        headers={"Content-Disposition": f"attachment; filename=booking-{booking_id}.ics"}
+    )
+```
+
+> **Import note:** `Response` must be imported from `fastapi.responses`. Add it alongside the existing `FastAPI, Depends, HTTPException` import at line 2.
+
+---
+
+### Step 3 — MCP: Add matching MCP tool in `server.py`
+**File:** `booking_system_backend/server.py` (in the MCP section, before `mcp_app = mcp.http_app()` ~line 107)
+
+```python
+@mcp.tool()
+def export_booking_ics(booking_id: int) -> str:
+    """Export a booking as an iCalendar (.ics) string.
+    Returns the iCalendar text for the booking, suitable for saving as a .ics file.
+    Raises an error if the booking is not found."""
+    db = SessionLocal()
+    try:
+        result = booking.get_booking_ics(db, booking_id)
+        if isinstance(result, ErrorResponse):
+            raise Exception(result.details or result.error)
+        return result
+    finally:
+        db.close()
+```
+
+---
+
+### Step 4 — Frontend: Add "Add to Calendar" button to `BookingCard.tsx`
+**File:** `booking_system_frontend/src/components/bookings/BookingCard.tsx`
+
+Add a handler using a temporary `<a download>` element (per issue spec — not Axios):
+
+```tsx
+const handleAddToCalendar = () => {
+  const url = `${import.meta.env.VITE_API_URL || '/api'}/bookings/${booking.booking_id}/export.ics`;
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `booking-${booking.booking_id}.ics`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+```
+
+Render alongside the existing Cancel button, gated on `canCancel`. Import `CalendarPlus` from `lucide-react` (already a dependency):
+
+```tsx
+{canCancel && (
+  <div className="flex gap-2">
+    <Button variant="secondary" size="sm" onClick={handleAddToCalendar} className="flex-1">
+      <CalendarPlus size={14} className="mr-1" /> Add to Calendar
+    </Button>
+    <Button variant="danger" size="sm" onClick={() => onCancel(booking.booking_id)}
+      isLoading={isCancelling} className="flex-1">
+      Cancel Booking
+    </Button>
+  </div>
+)}
+```
+
+> Check what variants the `Button` component supports before using `"secondary"` — read `src/components/common/Button.tsx` first.
+
+---
+
+### Step 5 — Tests: Service unit tests in `test_services.py`
+**File:** `booking_system_backend/tests/test_services.py`
+
+Add a `TestBookingIcsService` class with three cases (following existing fixture/class pattern):
+
+- `test_get_booking_ics_returns_string` — valid booking returns a `str` starting with `BEGIN:VCALENDAR`
+- `test_get_booking_ics_contains_required_fields` — checks for `SUMMARY`, `LOCATION`, `DTSTART`, `DTEND`, `DESCRIPTION`, `UID`
+- `test_get_booking_ics_not_found` — missing booking returns `ErrorResponse`
+
+---
+
+### Step 6 — Tests: REST tests in `test_rest.py`
+**File:** `booking_system_backend/tests/test_rest.py`
+
+Add a `TestBookingIcsEndpoint` class with two tests:
+
+- `test_export_ics_returns_200_with_content_type` — creates user + flight + booking, calls `GET /bookings/{id}/export.ics`, asserts HTTP 200, `Content-Type: text/calendar`, and `Content-Disposition` header present
+- `test_export_ics_returns_404_when_not_found` — calls with a nonexistent booking ID, asserts HTTP 404
+
+## Data Shape Notes
+
+| Field | Source | ICS Field |
+|-------|--------|-----------|
+| `flight.departure_time` | `"2099-01-01 09:00"` string (`models.py`) | `DTSTART` |
+| `flight.arrival_time` | `"2099-01-01 17:00"` string | `DTEND` |
+| `flight.origin` / `flight.destination` | `Flight` model | `SUMMARY`, `LOCATION` |
+| `booking.booking_id` | `Booking` model | `UID`, `DESCRIPTION` |
+| `booking.seat_class` + `booking.price_paid` | `Booking` model | `DESCRIPTION` |
+
+## Acceptance Criteria
+
+- [ ] `GET /bookings/{id}/export.ics` returns HTTP 200 with `Content-Type: text/calendar` and a valid iCalendar body
+- [ ] `GET /bookings/{id}/export.ics` returns HTTP 404 when booking ID does not exist
+- [ ] Event contains `SUMMARY`, `LOCATION`, `DTSTART`, `DTEND`, `DESCRIPTION`, `UID`
+- [ ] Matching MCP tool added alongside the REST endpoint
+- [ ] "Add to Calendar" button on active booking cards triggers a browser file download
+- [ ] File opens correctly in Apple Calendar and Google Calendar
+- [ ] `cd booking_system_backend && pytest` passes with new tests included
+
+## Validation
+
+```bash
+cd booking_system_backend && pytest
+cd booking_system_frontend && npm run lint
+```


### PR DESCRIPTION
# Summary

Adds ICS calendar export functionality to the booking system. Users can now export any non-cancelled booking as an RFC 5545-compliant `.ics` calendar file, either via a new REST endpoint or through the MCP tool interface. A new "Add to Calendar" button is also surfaced on each booking card in the frontend.

# Files Changed

📄 `.bob/custom_modes.yaml`

Uncomments the previously disabled `code-reviewer` and `deploy-engineer` custom AI mode definitions, making both modes active and available for use.

---

📄 `booking_system_backend/server.py`

- Imports `Response` from `fastapi.responses` to support returning raw file content.
- Adds a new `export_booking_ics` MCP tool that wraps the booking service's ICS generation function and exposes it to MCP clients.
- Adds a new REST endpoint `GET /bookings/{booking_id}/export.ics` that returns the ICS content as a downloadable `text/calendar` file with an appropriate `Content-Disposition` header, or a 404 if the booking is not found.

---

📄 `booking_system_backend/services/booking.py`

- Adds `timezone` to the `datetime` import for timezone-aware UTC timestamps.
- Implements the new `get_booking_ics` service function that queries a booking and its associated flight, then generates a well-formed RFC 5545 `.ics` string. Includes `VCALENDAR` and `VEVENT` blocks with all required fields (`UID`, `DTSTAMP`, `DTSTART`, `DTEND`, `SUMMARY`, `DESCRIPTION`, `LOCATION`). Returns an `ErrorResponse` if the booking or flight is not found.

---

📄 `booking_system_backend/tests/test_rest.py`

Adds a `TestBookingIcsEndpoint` test class covering the new REST endpoint. Includes a helper to seed a user, flight, and booking, and tests that:
- A valid booking returns HTTP 200 with a `text/calendar` content type, correct `Content-Disposition` header, and a body beginning with `BEGIN:VCALENDAR`.
- An unknown booking ID returns HTTP 404.

---

📄 `booking_system_backend/tests/test_services.py`

Adds a `TestBookingIcsService` test class covering the `get_booking_ics` service function directly. Tests verify that:
- A valid booking returns a string starting with `BEGIN:VCALENDAR`.
- The ICS output contains all required RFC 5545 fields and includes the correct flight origin and destination.
- A non-existent booking ID returns an `ErrorResponse` with error code `BOOKING_NOT_FOUND`.

---

📄 `booking_system_frontend/src/components/bookings/BookingCard.tsx`

- Imports the `CalendarPlus` icon from `lucide-react`.
- Introduces a `canExport` flag that is true for any non-cancelled booking.
- Replaces the single cancel button with a flex action-button row containing a new "Add to Calendar" anchor/button (linking to the ICS export endpoint) and the existing "Cancel Booking" button. The two buttons appear side by side when both are available.