### PR TITLE
docs: add AGENTS.md improvements and mode-specific bob rules

### DIFF
--- a/.bob/rules-agent/AGENTS.md
+++ b/.bob/rules-agent/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+This file provides guidance to agents when working with code in this repository.
+
+## Non-obvious coding rules
+
+- **MCP server before FastAPI** — `mcp = FastMCP(...)` must appear before `app = FastAPI(...)` in [`server.py`](../../booking_system_backend/server.py:22); lifespan composition breaks otherwise.
+- **MCP tools use raw `SessionLocal()`** — do NOT use `Depends(get_db)` inside `@mcp.tool()` functions; always call `db = SessionLocal()` / `db.close()` directly.
+- **Service functions return `Union`, not exceptions** — check `isinstance(result, ErrorResponse)` before treating a return value as success; never assume a non-None return is valid.
+- **Patch `SessionLocal` in two places in tests** — [`conftest.py`](../../booking_system_backend/tests/conftest.py:49) must patch both `db.SessionLocal` and `server.SessionLocal`; patching only one leaves MCP tools hitting the real DB.
+- **`book_flight()` validates name AND user_id together** — a valid `user_id` with a mismatched `name` returns `NAME_MISMATCH`, not `USER_NOT_FOUND`.
+- **Hold storage is per-user, not global** — [`holdStorage.ts`](../../booking_system_frontend/src/utils/holdStorage.ts) keys by `galaxium_holds_<userId>`; always pass `userId`.
+- **User auth is context-only** — use `useUser()` hook (throws if called outside `UserProvider`); do not read `localStorage` directly for user state.
+- **Frontend date/number formatting** — use helpers in [`formatters.ts`](../../booking_system_frontend/src/utils/formatters.ts); avoid raw `Intl` or `Date` formatting elsewhere.
+- **New backend endpoint checklist:** add (1) REST handler in `server.py`, (2) matching `@mcp.tool()` in `server.py`, (3) service function in `services/`.
+- **Java Lombok** — no manual getters/setters/constructors; use `@Data`/`@Builder`/`@RequiredArgsConstructor`. All service methods are `@Transactional`.
+- **`target/` and `dist/` are build outputs** — never edit files inside `booking_system_inventory_hold_service/target/` or `booking_system_frontend/dist/`.

--- a/.bob/rules-ask/AGENTS.md
+++ b/.bob/rules-ask/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md
+
+This file provides guidance to agents when working with code in this repository.
+
+## Non-obvious documentation context
+
+- **`server.py` is the single entry point for both REST and MCP** — it wires FastAPI + FastMCP together; REST and MCP tool docs are co-located there, not split.
+- **Service layer has no I/O except DB** — `services/{booking,flight,user}.py` are pure business logic; all HTTP and MCP plumbing lives in `server.py`.
+- **Error codes are documented in return values, not exceptions** — consult `ErrorResponse` in [`schemas.py`](../../booking_system_backend/schemas.py) for the full set of `error_code` strings.
+- **Tailwind color names are space-themed aliases** — `cosmic-purple`, `nebula-pink`, `alien-green`, etc. are defined in [`tailwind.config.js`](../../booking_system_frontend/tailwind.config.js); standard Tailwind color names are not used.
+- **Hold flow spans two services** — the quote→hold→confirm lifecycle involves both Python (`server.py` proxy endpoints) and Java (`HoldService`, `QuoteService`); neither service alone documents the full flow. See `e2e/test_holds.py` for the authoritative end-to-end sequence.
+- **Java `application.properties`** — `hold.duration.minutes=15` and the expiry scheduler interval (60 s) are the key tuning knobs; changing them requires updating `e2e/test_holds.py` timeouts.
+- **`holds.db` and `booking.db` are committed seed artefacts** — do not treat them as generated files; they bootstrap local dev.

--- a/.bob/rules-plan/AGENTS.md
+++ b/.bob/rules-plan/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+This file provides guidance to agents when working with code in this repository.
+
+## Non-obvious architectural constraints
+
+- **MCP and FastAPI share a lifespan** — `FastMCP` must be instantiated first; the combined lifespan is assembled via `mcp.http_app(lifespan=...)`. This ordering is load-bearing.
+- **SQLite is intentionally ephemeral on ECS** — `DATABASE_URL` is deliberately unset in production; each container task starts with a fresh DB seeded by `seed.py`. Do not design features that assume persistent state across deployments.
+- **Python proxies Java with HTTP 200 on error** — the proxy endpoints in `server.py` catch `httpx.HTTPError` and return `{"error": "..."}` with status 200. Any feature relying on HTTP error codes from proxy routes will silently fail.
+- **Cross-service booking confirmation is synchronous** — on hold confirm, Java calls Python `/internal/bookings/from-hold` synchronously via `RestTemplate`. There is no queue or retry; a Python downtime during confirm loses the booking.
+- **Hold expiry runs on Java scheduler, not Python** — `HoldExpirationScheduler` fires every 60 s; expired holds are never communicated back to Python. The two DBs can diverge.
+- **Frontend hold state is client-side only** — `holdStorage.ts` uses `localStorage`; clearing the browser storage orphans holds in the Java service with no UI recovery path.
+- **`SEED_DEMO_DATA=true` is destructive on restart** — re-seeding on every start means any data created in a previous run is wiped. Features that depend on persistent demo data must disable seeding.
+- **Java hold service is opt-in via Docker profile** — `profiles: [hold-service]` in `docker-compose.yml`; the hold/quote UI features are silently broken when the profile is not active.
+- **`docker-compose.e2e.yml` uses non-standard ports** — the e2e compose file remaps ports to avoid clashing with local dev; do not assume default port numbers in e2e test assertions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,10 +131,13 @@ scripts/
 ## Conventions
 
 - **Backend:** snake_case for functions/variables; PascalCase for classes/Pydantic models.
-- **Frontend API errors:** always inspect the `success` field or look for `error` in the body — HTTP status is not reliable for error detection (see [`api.ts`](booking_system_frontend/src/services/api.ts:112)).
-- **Custom Tailwind tokens:** space-themed palette defined in [`tailwind.config.js`](booking_system_frontend/tailwind.config.js) — do not assume standard Tailwind color names.
+- **Frontend API errors:** always inspect the `success` field or look for `error` in the body — HTTP status is not reliable for error detection (see [`api.ts`](booking_system_frontend/src/services/api.ts:22)).
+- **Custom Tailwind tokens:** space-themed palette defined in [`tailwind.config.js`](booking_system_frontend/tailwind.config.js) — do not assume standard Tailwind color names (`space-dark`, `space-blue`, `cosmic-purple`, `nebula-pink`, `alien-green`, `solar-orange`, `star-white`).
 - **Java:** Lombok `@Data`/`@Builder`/`@RequiredArgsConstructor` used throughout; no manual getters/setters. Service methods are `@Transactional`.
 - **New backend endpoints:** add REST handler + matching MCP tool if agent-accessible, following the pattern in `server.py`.
+- **Hold state is per-user localStorage** — [`holdStorage.ts`](booking_system_frontend/src/utils/holdStorage.ts) stores holds under `galaxium_holds_<userId>`. Not a global store; always pass `userId` when reading/writing.
+- **User session is localStorage-backed** — [`useUser.tsx`](booking_system_frontend/src/hooks/useUser.tsx) persists under key `galaxium_user`. Wrap components that need auth in `UserProvider`; access via `useUser()` hook only.
+- **Date formatting uses `date-fns`** — use [`formatters.ts`](booking_system_frontend/src/utils/formatters.ts) (`formatDate`, `formatTime`, `formatCurrency`, `calculateDuration`) rather than raw `Date` or `Intl` calls.
 
 ## Workflow
 


### PR DESCRIPTION
- Fix api.ts line reference in AGENTS.md (interceptor at line 22)
- Expand Tailwind custom token list with all six color names
- Add holdStorage.ts, useUser hook, and formatters.ts conventions
- Create .bob/rules-agent/AGENTS.md with non-obvious coding rules
- Create .bob/rules-ask/AGENTS.md with documentation context
- Create .bob/rules-plan/AGENTS.md with architectural constraints