### PR TITLE
feat: calendar export (.ics) for bookings — issue #44

### DIFF
--- a/booking_system_backend/server.py
+++ b/booking_system_backend/server.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.responses import Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastmcp import FastMCP
 from sqlalchemy.orm import Session
@@ -57,6 +58,21 @@ def get_bookings(user_id: int) -> list[BookingOut]:
     db = SessionLocal()
     try:
         return booking.get_bookings(db, user_id)
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def export_booking_ics(booking_id: int) -> str:
+    """Export a booking as an iCalendar (.ics) file string.
+    Returns a valid RFC 5545 iCalendar text for the specified booking_id.
+    Raises an error if the booking is not found."""
+    db = SessionLocal()
+    try:
+        result = booking.get_booking_ics(db, booking_id)
+        if isinstance(result, ErrorResponse):
+            raise Exception(result.details or result.error)
+        return result
     finally:
         db.close()
 
@@ -242,6 +258,23 @@ def book_flight_endpoint(request: BookingRequest, db: Session = Depends(get_db))
     Decrements available seats for the selected class if successful.
     """
     return booking.book_flight(db, request.user_id, request.name, request.flight_id, request.seat_class)
+
+
+@app.get("/bookings/{booking_id}/export.ics", tags=["Bookings"])
+def export_booking_ics_endpoint(booking_id: int, db: Session = Depends(get_db)):
+    """Export a booking as a downloadable iCalendar (.ics) file.
+
+    Returns a text/calendar file for the specified booking_id.
+    Returns 404 if the booking does not exist.
+    """
+    result = booking.get_booking_ics(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.error)
+    return Response(
+        content=result,
+        media_type="text/calendar",
+        headers={"Content-Disposition": f"attachment; filename=booking-{booking_id}.ics"},
+    )
 
 
 @app.get("/bookings/{user_id}", response_model=list[BookingOut], tags=["Bookings"])

--- a/booking_system_backend/services/booking.py
+++ b/booking_system_backend/services/booking.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import Session
-from datetime import datetime
+from datetime import datetime, timezone
 from models import User, Flight, Booking
 from schemas import BookingOut, ErrorResponse, SeatClass
 
@@ -126,3 +126,51 @@ def get_bookings(db: Session, user_id: int) -> list[BookingOut]:
     """Retrieve all bookings for a specific user."""
     bookings = db.query(Booking).filter(Booking.user_id == user_id).all()
     return [BookingOut.model_validate(b) for b in bookings]
+
+
+def _parse_datetime(dt_str: str) -> datetime:
+    """Parse a datetime string in either 'YYYY-MM-DD HH:MM' or 'YYYY-MM-DDTHH:MM:SSZ' format."""
+    for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+        try:
+            return datetime.strptime(dt_str, fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    raise ValueError(f"Unrecognised datetime format: {dt_str!r}")
+
+
+def get_booking_ics(db: Session, booking_id: int) -> str | ErrorResponse:
+    """Return a valid RFC 5545 iCalendar string for the given booking."""
+    booking = db.query(Booking).filter(Booking.booking_id == booking_id).first()
+    if not booking:
+        return ErrorResponse(
+            error="Booking not found",
+            error_code="BOOKING_NOT_FOUND",
+            details=f"Booking with ID {booking_id} not found.",
+        )
+
+    flight = db.query(Flight).filter(Flight.flight_id == booking.flight_id).first()
+
+    departure_dt = _parse_datetime(flight.departure_time)
+    arrival_dt = _parse_datetime(flight.arrival_time)
+    dtstamp = datetime.now(tz=timezone.utc)
+
+    def fmt(dt: datetime) -> str:
+        return dt.strftime("%Y%m%dT%H%M%SZ")
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Galaxium Travels//Booking Export//EN",
+        "BEGIN:VEVENT",
+        f"UID:booking-{booking_id}@galaxium-travels",
+        f"DTSTAMP:{fmt(dtstamp)}",
+        f"DTSTART:{fmt(departure_dt)}",
+        f"DTEND:{fmt(arrival_dt)}",
+        f"SUMMARY:Galaxium Travels: {flight.origin} \u2192 {flight.destination}",
+        f"LOCATION:{flight.origin} \u2192 {flight.destination}",
+        f"DESCRIPTION:Booking #{booking_id} | {booking.seat_class} class | {booking.status}",
+        "END:VEVENT",
+        "END:VCALENDAR",
+        "",
+    ]
+    return "\r\n".join(lines)

--- a/booking_system_backend/tests/test_rest.py
+++ b/booking_system_backend/tests/test_rest.py
@@ -870,3 +870,56 @@ class TestFlightsEndpointFiltering:
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 2
+
+
+class TestIcsEndpoint:
+    """Test GET /bookings/{booking_id}/export.ics endpoint."""
+
+    def test_ics_export_success(self, client, db_session, sample_user_data):
+        """Test successful ICS file download."""
+        # Register user
+        user_response = client.post("/register", json=sample_user_data)
+        user_id = user_response.json()["user_id"]
+
+        # Create flight
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-01-01 09:00",
+            arrival_time="2099-01-01 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1,
+        ))
+        db_session.commit()
+        flight = db_session.query(Flight).first()
+
+        # Create booking
+        db_session.add(Booking(
+            user_id=user_id,
+            flight_id=flight.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000000,
+        ))
+        db_session.commit()
+        booking = db_session.query(Booking).first()
+
+        response = client.get(f"/bookings/{booking.booking_id}/export.ics")
+
+        assert response.status_code == 200
+        assert "text/calendar" in response.headers["content-type"]
+        assert "attachment" in response.headers["content-disposition"]
+        body = response.text
+        assert "BEGIN:VCALENDAR" in body
+        assert "BEGIN:VEVENT" in body
+        assert "SUMMARY:Galaxium Travels" in body
+        assert "DTSTART:" in body
+        assert "DTEND:" in body
+
+    def test_ics_export_not_found(self, client, db_session):
+        """Test ICS export returns 404 for a non-existent booking."""
+        response = client.get("/bookings/99999/export.ics")
+        assert response.status_code == 404

--- a/booking_system_backend/tests/test_services.py
+++ b/booking_system_backend/tests/test_services.py
@@ -973,3 +973,92 @@ class TestFlightFiltering:
 
         results = flight.list_flights(db_session, min_price=10000000)
         assert len(results) == 0
+
+
+class TestBookingIcsService:
+    """Test get_booking_ics service function."""
+
+    def test_ics_success(self, db_session):
+        """Test successful ICS generation for an existing booking."""
+        db_session.add(User(name="Test User", email="test@example.com"))
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time="2099-01-01 09:00",
+            arrival_time="2099-01-01 17:00",
+            base_price=1000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1,
+        ))
+        db_session.commit()
+
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=1000000,
+        ))
+        db_session.commit()
+        booking_obj = db_session.query(Booking).first()
+
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+
+        assert isinstance(result, str)
+        assert "BEGIN:VCALENDAR" in result
+        assert "BEGIN:VEVENT" in result
+        assert "END:VEVENT" in result
+        assert "END:VCALENDAR" in result
+        assert "SUMMARY:Galaxium Travels" in result
+        assert "LOCATION:" in result
+        assert "DTSTART:" in result
+        assert "DTEND:" in result
+        assert f"UID:booking-{booking_obj.booking_id}@galaxium-travels" in result
+        # RFC 5545 requires CRLF line endings
+        assert "\r\n" in result
+
+    def test_ics_success_iso_format(self, db_session):
+        """Test ICS generation with ISO 8601 datetime format in the DB."""
+        db_session.add(User(name="Test User", email="test@example.com"))
+        db_session.add(Flight(
+            origin="Luna",
+            destination="Jupiter",
+            departure_time="2099-06-15T08:30:00Z",
+            arrival_time="2099-06-15T22:00:00Z",
+            base_price=2000000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1,
+        ))
+        db_session.commit()
+
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-06-15 09:00",
+            seat_class="business",
+            price_paid=5000000,
+        ))
+        db_session.commit()
+        booking_obj = db_session.query(Booking).first()
+
+        result = booking.get_booking_ics(db_session, booking_obj.booking_id)
+        assert isinstance(result, str)
+        assert "20990615T083000Z" in result
+        assert "20990615T220000Z" in result
+
+    def test_ics_not_found(self, db_session):
+        """Test ICS generation for a non-existent booking returns ErrorResponse."""
+        result = booking.get_booking_ics(db_session, 99999)
+
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "BOOKING_NOT_FOUND"

--- a/booking_system_frontend/src/components/bookings/BookingCard.tsx
+++ b/booking_system_frontend/src/components/bookings/BookingCard.tsx
@@ -72,6 +72,17 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
 
   const canCancel = booking.status === 'booked';
 
+  const handleAddToCalendar = () => {
+    const baseUrl = import.meta.env.VITE_API_URL || '/api';
+    const url = `${baseUrl}/bookings/${booking.booking_id}/export.ics`;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `booking-${booking.booking_id}.ics`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -153,17 +164,28 @@ export const BookingCard = ({ booking, flight, onCancel, isCancelling }: Booking
           <span>Booked on {formatDate(booking.booking_time)}</span>
         </div>
 
-        {/* Cancel Button */}
+        {/* Action Buttons */}
         {canCancel && (
-          <Button
-            variant="danger"
-            size="sm"
-            onClick={() => onCancel(booking.booking_id)}
-            isLoading={isCancelling}
-            className="w-full"
-          >
-            Cancel Booking
-          </Button>
+          <div className="flex flex-col gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleAddToCalendar}
+              className="w-full"
+            >
+              <Calendar size={14} className="mr-1" />
+              Add to Calendar
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => onCancel(booking.booking_id)}
+              isLoading={isCancelling}
+              className="w-full"
+            >
+              Cancel Booking
+            </Button>
+          </div>
         )}
       </Card>
     </motion.div>


### PR DESCRIPTION
## Summary

Implements `GET /bookings/{id}/export.ics` backend endpoint and an "Add to Calendar" download button on the booking card, closing issue #44.

---

## Changes

### Backend — `booking_system_backend/services/booking.py`
- Added `get_booking_ics(db, booking_id)` service function
- Builds a valid RFC 5545 iCalendar string using stdlib only (no third-party packages)
- Handles both `YYYY-MM-DD HH:MM` and `YYYY-MM-DDTHH:MM:SSZ` datetime formats
- Returns `ErrorResponse(BOOKING_NOT_FOUND)` when the booking does not exist
- CRLF line endings throughout; fields: `UID`, `SUMMARY`, `LOCATION`, `DTSTART`, `DTEND`, `DESCRIPTION`, `DTSTAMP`

### Backend — `booking_system_backend/server.py`
- Added `GET /bookings/{booking_id}/export.ics` REST endpoint (registered before `/bookings/{user_id}` to avoid route shadowing)
- Returns `text/calendar` with `Content-Disposition: attachment` on success; HTTP 404 on missing booking
- Added `export_booking_ics` MCP tool following the existing `SessionLocal()`/`finally` pattern

### Backend — Tests
- `TestBookingIcsService` (3 tests): success with space-separated format, success with ISO 8601 format, not-found returns `ErrorResponse`
- `TestIcsEndpoint` (2 tests): HTTP 200 with correct headers + body assertions, HTTP 404
- **All 77 tests pass**

### Frontend — `booking_system_frontend/src/components/bookings/BookingCard.tsx`
- Added `handleAddToCalendar()` using a temporary `<a download>` element (not Axios)
- "Add to Calendar" button rendered above Cancel, gated on `booking.status === 'booked'`
- Uses existing `Calendar` icon from `lucide-react` and `secondary` Button variant

---

## Acceptance criteria

- [x] `GET /bookings/{id}/export.ics` returns HTTP 200 with `Content-Type: text/calendar` and a valid iCalendar body
- [x] `GET /bookings/{id}/export.ics` returns HTTP 404 when booking ID does not exist
- [x] Event contains `SUMMARY`, `LOCATION`, `DTSTART`, `DTEND`, `DESCRIPTION`, `UID`
- [x] Matching MCP tool added alongside the REST endpoint
- [x] "Add to Calendar" button on active booking cards triggers a browser file download
- [x] `pytest` passes with new tests included (77/77)