### PR TITLE
fix: update Bob review workflow for Bob Shell V2

### DIFF
--- a/.github/workflows/bob-review.yml
+++ b/.github/workflows/bob-review.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: '22'
 
       - name: Install Bob Shell
-        run: curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash -s -- --pm npm
+        run: curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash
 
       - name: Fetch PR diff
         env:
@@ -40,7 +40,7 @@ jobs:
         env:
           BOBSHELL_API_KEY: ${{ secrets.BOBSHELL_API_KEY }}
         run: |
-          bob --accept-license --auth-method api-key -p "$(cat <<'EOF'
+          cat > prompt.txt << 'PROMPT'
           You are reviewing a pull request on the IBM/galaxium-travels repo, non-interactively, in CI.
           Speed is critical — follow the two-pass process below exactly and do not deviate.
 
@@ -56,7 +56,7 @@ jobs:
 
           ## PASS 1 — fast scan (always do this; keep it short)
 
-          Read AGENTS.md (for footguns and conventions) and pr.diff simultaneously — these two reads are your entire scan.
+          Read AGENTS.md (for footguns and conventions) and @pr.diff simultaneously — these two reads are your entire scan.
           From the diff alone, decide:
           - Which category does this PR belong to?
           - Are there any *obvious* red flags? (e.g. a removed safety check, a clearly wrong type, a secret committed, an import that cannot exist)
@@ -92,8 +92,8 @@ jobs:
           - Do not approve or block the PR — you are leaving a comment, not a verdict.
 
           Do not modify any source files. Do not run the test suite. Do not write any files.
-          EOF
-          )" 2>&1 | tee bob_output.txt
+          PROMPT
+          cat prompt.txt | bob --accept-license --auth-method api-key --hide-intermediary-output 2>&1 | tee bob_output.txt
 
       - name: Extract review from Bob's stdout
         run: |


### PR DESCRIPTION
## What

Updates `.github/workflows/bob-review.yml` to work with the Bob Shell V2 API.

## Changes

| Line | Change |
|------|--------|
| Install step | Removed `--pm npm` flag — not part of V2's `bobshell.sh` interface |
| Bob invocation | Replaced fragile `bob -p "$(cat <<'EOF' ... EOF)"` with `cat > prompt.txt | bob` — the pattern explicitly recommended by V2 docs for multi-line prompts |
| Prompt text | Changed `pr.diff` → `@pr.diff` so Bob uses the V2 file-reference syntax |
| Bob invocation | Added `--hide-intermediary-output` so only the final answer lands in `bob_output.txt`, making the `<<<BOB_REVIEW_BEGIN>>>` marker extraction reliable |

## Why

The workflow was broken after the Bob Shell V2 release due to the install script flag change and the heredoc-in-subshell quoting pattern no longer working reliably.