### PR TITLE
fix: restore --pm npm flag to bobshell.sh install in CI

### DIFF
--- a/.github/workflows/bob-review.yml
+++ b/.github/workflows/bob-review.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: '22'
 
       - name: Install Bob Shell
-        run: curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash
+        run: curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash -s -- --pm npm
 
       - name: Fetch PR diff
         env:


### PR DESCRIPTION
## What

Restores the `--pm npm` flag to the Bob Shell install step in the Bob review workflow.

## Why

After merging #101, the workflow was still broken. Without `--pm npm`, the install script prompts interactively for a package manager selection, which hangs indefinitely in CI because there is no TTY (`/dev/tty: No such device or address`). Passing `--pm npm` via `bash -s -- --pm npm` skips the prompt.