### PR TITLE
fix: remove --auth-method flag from bob-review workflow

### DIFF
--- a/.github/workflows/bob-review.yml
+++ b/.github/workflows/bob-review.yml
@@ -93,7 +93,7 @@ jobs:
 
           Do not modify any source files. Do not run the test suite. Do not write any files.
           PROMPT
-          cat prompt.txt | bob --accept-license --auth-method api-key --hide-intermediary-output 2>&1 | tee bob_output.txt
+          cat prompt.txt | bob --accept-license --hide-intermediary-output 2>&1 | tee bob_output.txt
 
       - name: Extract review from Bob's stdout
         run: |


### PR DESCRIPTION
## What

Removes `--auth-method api-key` from the Bob Shell invocation in the CI review workflow.

## Why

The installed version of Bob Shell does not recognise `--auth-method` as a valid flag (`error: Invalid argument — unknown option '--auth-method'`). The flag does not appear in the CLI args reference. With `BOBSHELL_API_KEY` already set as an environment variable in the step, Bob authenticates automatically without needing the explicit flag.