### PR TITLE
fix: use 'bob run' for non-interactive execution in CI

### DIFF
--- a/.github/workflows/bob-review.yml
+++ b/.github/workflows/bob-review.yml
@@ -93,7 +93,7 @@ jobs:
 
           Do not modify any source files. Do not run the test suite. Do not write any files.
           PROMPT
-          cat prompt.txt | bob --accept-license --hide-intermediary-output 2>&1 | tee bob_output.txt
+          bob run --accept-license --trust "$(cat prompt.txt)" 2>&1 | tee bob_output.txt
 
       - name: Extract review from Bob's stdout
         run: |


### PR DESCRIPTION
## What

Replaces the broken `cat prompt.txt | bob --accept-license --hide-intermediary-output` invocation with the correct `bob run` subcommand.

## Why

Bob Shell 2.0.0 uses a subcommand-based CLI. The top-level `bob` command does not accept `--hide-intermediary-output`, `--auth-method`, or `-p`. The correct interface for non-interactive/headless execution is `bob run [prompt]`.

Confirmed from `bob run --help` on the installed 2.0.0 binary:
- Authentication is automatic via `BOBSHELL_API_KEY` env var (no flag needed)
- `--trust` marks the CI workspace as trusted
- `--accept-license` accepts the license non-interactively