### PR TITLE
fix: use findall+last match to skip marker in prompt template

### DIFF
--- a/.github/workflows/bob-review.yml
+++ b/.github/workflows/bob-review.yml
@@ -100,9 +100,9 @@ jobs:
           python3 -c "
           import re, sys
           text = open('bob_output.txt').read()
-          m = re.search(r'<<<BOB_REVIEW_BEGIN>>>(.*?)<<<BOB_REVIEW_END>>>', text, re.DOTALL)
-          if m:
-              print(m.group(1).strip())
+          matches = re.findall(r'<<<BOB_REVIEW_BEGIN>>>(.*?)<<<BOB_REVIEW_END>>>', text, re.DOTALL)
+          if matches:
+              print(matches[-1].strip())
           else:
               print('_Bob did not produce a structured review. Raw output below._\n')
               print(text)


### PR DESCRIPTION
## What

Fixes the review extraction step picking up the wrong content.

## Why

`re.search` was matching the `<<<BOB_REVIEW_BEGIN>>>` / `<<<BOB_REVIEW_END>>>` example markers that appear inside `prompt.txt` (which Bob echoes back as part of its output) rather than the markers wrapping Bob's actual review. Switching to `re.findall(...)` and taking `[-1]` (the last match) ensures we always get Bob's real review, not the template.