### PR TITLE
feat: rename header to 'Galaxium Travel Agency'

### DIFF
--- a/booking_system_frontend/src/components/layout/Header.tsx
+++ b/booking_system_frontend/src/components/layout/Header.tsx
@@ -27,7 +27,7 @@ export const Header = () => {
               <Rocket className="text-cosmic-purple" size={32} />
             </motion.div>
             <span className="text-2xl font-bold bg-cosmic-gradient bg-clip-text text-transparent">
-              Galaxium Travels
+              Galaxium Travel Agency
             </span>
           </Link>
 


### PR DESCRIPTION
## Summary

Updates the application header display name from **Galaxium Travels** to **Galaxium Travel Agency**.

## Changes

- Updated the brand name text in `booking_system_frontend/src/components/layout/Header.tsx` (line 30)

## Why

Aligns the header with the full agency branding name for consistency across the product.