### PR TITLE
feat: add cancellation refund preview (booking + frontend + types)

### DIFF
--- a/.bob/custom_modes.yaml
+++ b/.bob/custom_modes.yaml
@@ -1,47 +1,47 @@
-# customModes:
-#   - slug: code-reviewer
-#     name: Code Reviewer
-#     roleDefinition: >-
-#       You are a strict, read-only code reviewer. Your job is to read code and
-#       provide clear, actionable feedback on quality: naming conventions, code
-#       structure, consistency with project style, obvious bugs, dead code, and
-#       anything that would make the code harder to maintain or understand.
+customModes:
+  - slug: code-reviewer
+    name: Code Reviewer
+    roleDefinition: >-
+      You are a strict, read-only code reviewer. Your job is to read code and
+      provide clear, actionable feedback on quality: naming conventions, code
+      structure, consistency with project style, obvious bugs, dead code, and
+      anything that would make the code harder to maintain or understand.
 
-#       You never edit or create files. You never run the application. You may run
-#       linters and test suites to gather evidence, but only to inform your review.
+      You never edit or create files. You never run the application. You may run
+      linters and test suites to gather evidence, but only to inform your review.
 
-#       Your output is always a structured review: a short summary of findings,
-#       followed by specific issues with file references and line numbers where
-#       relevant. Distinguish between blocking issues (must fix) and suggestions
-#       (nice to have). Be direct and precise - do not pad feedback with praise.
-#     whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
-#     description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#   - slug: deploy-engineer
-#     name: Deploy Engineer
-#     roleDefinition: >-
-#       You are a Deploy Engineer. Your sole responsibility is making sure this
-#       project deploys correctly and reliably. You are an expert in the deployment
-#       scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
-#       infrastructure-as-code in this project.
+      Your output is always a structured review: a short summary of findings,
+      followed by specific issues with file references and line numbers where
+      relevant. Distinguish between blocking issues (must fix) and suggestions
+      (nice to have). Be direct and precise - do not pad feedback with praise.
+    whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
+    description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
+    groups:
+      - read
+      - execute
+      - skill
+  - slug: deploy-engineer
+    name: Deploy Engineer
+    roleDefinition: >-
+      You are a Deploy Engineer. Your sole responsibility is making sure this
+      project deploys correctly and reliably. You are an expert in the deployment
+      scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
+      infrastructure-as-code in this project.
 
-#       You only read and edit files inside the scripts/ directory. You do not
-#       touch application source code, frontend assets, or test files. If a
-#       deployment problem traces back to application code, you report it clearly
-#       but do not fix it yourself.
+      You only read and edit files inside the scripts/ directory. You do not
+      touch application source code, frontend assets, or test files. If a
+      deployment problem traces back to application code, you report it clearly
+      but do not fix it yourself.
 
-#       When reviewing or editing deploy scripts, you check for: missing error
-#       handling, hardcoded secrets or environment assumptions, non-idempotent
-#       operations, missing health checks, and steps that could cause downtime.
-#       You run commands to validate and test deploy scripts where possible.
-#     whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
-#     description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#       - - edit
-#         - fileRegex: "scripts/.*"
+      When reviewing or editing deploy scripts, you check for: missing error
+      handling, hardcoded secrets or environment assumptions, non-idempotent
+      operations, missing health checks, and steps that could cause downtime.
+      You run commands to validate and test deploy scripts where possible.
+    whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
+    description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
+    groups:
+      - read
+      - execute
+      - skill
+      - - edit
+        - fileRegex: "scripts/.*"

--- a/REFUND-PREVIEW-PLAN-REVIEWED.md
+++ b/REFUND-PREVIEW-PLAN-REVIEWED.md
@@ -1,0 +1,38 @@
+# Refund Preview on Cancel — Reviewed Plan
+
+> Closes GitHub Issue #43  
+> Status: **Draft · Reviewed**
+
+---
+
+## Summary
+
+Add a cancellation-policy preview to the cancel modal in `MyBookings.tsx`. Before confirming a cancellation, the user sees a tier badge, colour-coded proportion bar, per-row breakdown, and a net-cash summary. The backend owns all policy logic via `GET /bookings/{id}/cancellation-preview`; actual refund processing is out of scope. Three key decisions were made during review: route ordering will be enforced with an inline protective comment, the tier helper will use `timedelta.days` integer-floor with a documented docstring, and frontend error handling uses a single generic fallback for all failure modes.
+
+---
+
+## Key Decisions
+
+| Decision                            | Choice                                                                                                                                                                         | Rationale                                                                                                             |
+| -------------------------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| -----------------------------------------------------------------------------------------------------------------------|
+| Route ordering enforcement          | Add inline comment above `GET /bookings/{user_id}`: *"NOTE: /bookings/{id}/cancellation-preview must be registered above this route — FastAPI matches in registration order."* | Prevents silent shadowing without adding test complexity; makes the footgun self-documenting.                         |
+| Days-to-departure calculation       | `timedelta.days` integer floor                                                                                                                                                 | Matches the policy table exactly, keeps the helper simple; rounding behaviour documented in the function's docstring. |
+| Frontend error fallback granularity | Single generic fallback for all errors (network, 404, etc.)                                                                                                                    | Keeps the UI simple; the cancel endpoint itself returns a proper error if the booking is already gone.                |
+
+---
+
+## Open Items
+
+- No integration/e2e tests planned for the new endpoint — consider adding a smoke test to `e2e/test_smoke.py` if the endpoint is agent-accessible.
+- `datetime.utcnow()` is deprecated in Python 3.12+; plan uses it for now but a future cleanup should switch to `datetime.now(timezone.utc)`.
+- Icon library for the frontend breakdown rows (arrow-return, x-circle, ticket) needs to be confirmed against existing imports in `BookingCard.tsx` before implementation.
+
+---
+
+## Next Steps
+
+1. **Sub-Task 1** — Add `CancellationPreview` Pydantic schema to `schemas.py`; implement `compute_cancellation_preview` pure helper and `get_cancellation_preview` service wrapper in `booking.py`.
+2. **Sub-Task 2** — Register `GET /bookings/{id}/cancellation-preview` in `server.py` **before** the `GET /bookings/{user_id}` wildcard; add the protective inline comment above that wildcard.
+3. **Sub-Task 3** — Write `pytest` unit tests covering all four tiers and both date string formats; confirm all tests pass.
+4. **Sub-Task 4** — Add `CancellationPreview` TypeScript interface to `types/index.ts` and `getCancellationPreview` function to `api.ts`.
+5. **Sub-Task 5** — Replace the cancel modal body in `MyBookings.tsx` with tier badge, proportion bar, per-row breakdown, and summary row; handle loading spinner and error fallback; run frontend lint/typecheck.

--- a/REFUND-PREVIEW-PLAN.md
+++ b/REFUND-PREVIEW-PLAN.md
@@ -1,0 +1,164 @@
+# Refund Preview on Cancel — Implementation Plan
+
+> Closes GitHub Issue #43
+
+## Overview
+
+Add a cancellation-policy preview to the cancel modal in `MyBookings.tsx`. Before the user confirms a cancellation, they will see a refund/fee/credit breakdown based on how many days remain until departure.
+
+**Policy tiers:**
+| Days to departure | Cash refund | Fee | Travel credit |
+|---|---|---|---|
+| 7+ days | 100% | 0% | 0% |
+| 3–6 days | 75% | 10% | 15% |
+| 1–2 days | 0% | 25% | 25% |
+| Same-day (0) | 0% | 0% | 0% (total forfeit) |
+
+**Approach:** Backend owns the policy calculation and exposes `GET /bookings/{id}/cancellation-preview`. The frontend fetches this preview when the cancel modal opens and renders the breakdown. Actual refund processing is out of scope.
+
+**Key constraint:** `GET /bookings/{id}/cancellation-preview` must be registered in `server.py` *before* `GET /bookings/{user_id}` — FastAPI matches in registration order, and the existing wildcard would shadow the new route otherwise.
+
+---
+
+## Sub-Task 1 — Backend: cancellation policy helper + service function
+
+**Status:** `[ ] pending`
+
+### Intent
+Encapsulate all cancellation-policy logic in a single, testable helper that accepts `price_paid` and `departure_time` (as a string) and returns the breakdown. The helper must be independent of the database so it can be unit-tested without fixtures.
+
+### Expected Outcomes
+- A pure function `compute_cancellation_preview(price_paid: int, departure_time: str) -> CancellationPreview` exists in `booking_system_backend/services/booking.py` (or a new `cancellation.py` module — follow existing file patterns).
+- The function handles all three departure-time string formats: `%Y-%m-%d %H:%M`, `%Y-%m-%dT%H:%M:%S`, `%Y-%m-%dT%H:%M:%SZ`.
+- A Pydantic schema `CancellationPreview` exists in `booking_system_backend/schemas.py` with fields: `tier_label: str`, `refund_amount: int`, `fee_amount: int`, `credit_amount: int`, `total_forfeited: int`, `price_paid: int`.
+- A service wrapper `get_cancellation_preview(db, booking_id) -> CancellationPreview | ErrorResponse` queries the booking + its flight and calls the pure helper.
+
+### Todo List
+1. Add `CancellationPreview` Pydantic schema to `booking_system_backend/schemas.py`.
+2. Add `compute_cancellation_preview(price_paid, departure_time)` pure helper in the booking service — implement the four policy tiers using `datetime.utcnow()` for the current time reference.
+3. Add `get_cancellation_preview(db, booking_id)` service function that looks up the booking and its flight, then delegates to the helper. Return `ErrorResponse` if the booking does not exist.
+4. Ensure the helper raises a clear `ValueError` for unrecognised date formats (do not silently return wrong numbers).
+
+### Relevant Context
+- `booking_system_backend/services/booking.py` — existing service patterns; `cancel_booking` shows how to look up a booking and return `BookingOut | ErrorResponse`.
+- `booking_system_backend/schemas.py` lines 58-67 — `BookingOut` as a pattern for the new schema.
+- `booking_system_backend/models.py` — `Booking` has `price_paid` and `flight_id`; `Flight` has `departure_time`.
+- `booking_system_backend/seed.py` lines 38-48 — live data uses `"YYYY-MM-DDTHH:MM:SSZ"` format. Test fixtures use `"YYYY-MM-DD HH:MM"`.
+
+---
+
+## Sub-Task 2 — Backend: REST endpoint + MCP tool
+
+**Status:** `[ ] pending`
+
+### Intent
+Expose the cancellation preview via HTTP so the frontend can fetch it, and automatically register it as an MCP tool for agent use.
+
+### Expected Outcomes
+- `GET /bookings/{id}/cancellation-preview` is registered in `server.py` and returns `CancellationPreview`.
+- The route is registered **before** `GET /bookings/{user_id}` (currently around line 169) to prevent route shadowing.
+- Because `server.py` uses `FastApiMCP`, the endpoint is automatically available as an MCP tool — no separate `@mcp.tool` decorator needed.
+- Returns HTTP 404 (via `HTTPException`) when the booking does not exist.
+
+### Todo List
+1. In `booking_system_backend/server.py`, add the import for `get_cancellation_preview` and `CancellationPreview`.
+2. Register `GET /bookings/{id}/cancellation-preview` before the existing `GET /bookings/{user_id}` route.
+3. In the handler, call `get_cancellation_preview(db, id)`, check for `ErrorResponse`, and raise `HTTPException(status_code=404)` if so.
+
+### Relevant Context
+- `booking_system_backend/server.py` lines 169-172 — `GET /bookings/{user_id}` is the route that would shadow the new endpoint if ordering is wrong.
+- AGENTS.md footgun: "FastAPI matches in registration order and the wildcard will shadow the two-segment path otherwise."
+- `server.py` lines 175-186 — `POST /cancel/{booking_id}` as a pattern for error handling.
+
+---
+
+## Sub-Task 3 — Backend: unit tests for the policy helper
+
+**Status:** `[ ] pending`
+
+### Intent
+Verify the four policy tiers and the multi-format date parsing are correct before the frontend depends on this logic.
+
+### Expected Outcomes
+- Tests in `booking_system_backend/tests/test_services.py` (or a new `test_cancellation.py`) cover:
+  - 7+ days out → full refund, zero fee, zero credit.
+  - 3–6 days out → 75% refund, 10% fee, 15% credit.
+  - 1–2 days out → 0% refund, 25% fee, 25% credit.
+  - Same-day → 0% refund, 0% fee, 0% credit (total forfeit).
+  - Date string in `"YYYY-MM-DD HH:MM"` format (test-fixture format).
+  - Date string in `"YYYY-MM-DDTHH:MM:SSZ"` format (seed/live format).
+- All tests pass with `pytest booking_system_backend/`.
+
+### Todo List
+1. Write `test_compute_cancellation_preview_*` tests using the pure helper (no DB needed).
+2. Include a test with departure_time taken verbatim from `seed.py` (e.g. `"2099-01-01T09:00:00Z"`).
+3. Include a test with departure_time in `"YYYY-MM-DD HH:MM"` format matching test fixtures in `conftest.py`.
+4. Run `pytest booking_system_backend/` and confirm all tests pass.
+
+### Relevant Context
+- `booking_system_backend/tests/conftest.py` — `sample_flight_data` at lines 73-84 uses `"2099-01-01 09:00"` format.
+- `booking_system_backend/seed.py` lines 38-48 — live format `"2099-01-01T09:00:00Z"`.
+- `booking_system_backend/tests/test_services.py` — existing pattern for service unit tests.
+
+---
+
+## Sub-Task 4 — Frontend: API function + TypeScript type
+
+**Status:** `[ ] pending`
+
+### Intent
+Add a typed API call so the cancel modal can fetch the preview without duplicating fetch logic.
+
+### Expected Outcomes
+- `CancellationPreview` TypeScript interface added to `booking_system_frontend/src/types/index.ts`.
+- `getCancellationPreview(bookingId: number): Promise<CancellationPreview | ErrorResponse>` added to `booking_system_frontend/src/services/api.ts`.
+- The function follows the existing pattern (uses the `api` axios instance, checks `success: false` for errors).
+
+### Todo List
+1. Add `CancellationPreview` interface to `booking_system_frontend/src/types/index.ts` matching the backend schema fields: `tier_label`, `refund_amount`, `fee_amount`, `credit_amount`, `total_forfeited`, `price_paid`.
+2. Add `getCancellationPreview` in `booking_system_frontend/src/services/api.ts` — `GET /bookings/${bookingId}/cancellation-preview`.
+
+### Relevant Context
+- `booking_system_frontend/src/types/index.ts` lines 20-28 — `Booking` interface as a pattern.
+- `booking_system_frontend/src/services/api.ts` lines 132-135 — `getUserBookings` as a pattern; lines 140-147 — `cancelBooking` as a pattern.
+- AGENTS.md convention: "always inspect the `success` field or look for `error` in the body — HTTP status is not reliable."
+
+---
+
+## Sub-Task 5 — Frontend: cancel modal UI
+
+**Status:** `[ ] pending`
+
+### Intent
+Replace the generic "are you sure?" modal with a rich refund-preview block. The user sees the breakdown before confirming.
+
+### Expected Outcomes
+- When the user clicks "Cancel Booking", `MyBookings.tsx` calls `getCancellationPreview` and stores the result in state.
+- While the preview is loading, the modal shows a spinner/skeleton.
+- On success, the modal displays:
+  - A **policy tier badge** at the top (e.g. "Full Refund ✓", "Partial Refund", "Non-refundable").
+  - A **segmented proportion bar** with colour-coded bands for refund / fee / credit.
+  - **Per-row breakdown** with icons: refund (arrow-return), fee (x-circle), travel credit (ticket).
+  - A **"You'll receive back" summary row** (divider + net cash refund) at the bottom.
+  - All amounts formatted via the existing `formatCurrency()` utility.
+- The "Cancel Booking" confirm button remains at the bottom; "Keep Booking" dismisses.
+- On preview fetch error, the modal falls back to the existing generic confirmation text (do not block cancellation).
+- The frontend passes `npm run lint` (or equivalent check).
+
+### Todo List
+1. Add state to `MyBookings.tsx`: `previewData: CancellationPreview | null`, `previewLoading: boolean`, `previewError: boolean`.
+2. Modify `handleCancelClick` to call `getCancellationPreview(bookingId)` and populate `previewData` before showing the modal.
+3. Replace the modal body in `MyBookings.tsx` (lines 252-276) with the new breakdown UI.
+4. Implement the proportion bar as an inline `<div>` with three colour-coded segments (widths are `refund/price_paid * 100%`, etc.). Use existing Tailwind space-theme tokens.
+5. Add per-row icons — use whatever icon library is already imported in the project (check existing imports in `BookingCard.tsx` or `MyBookings.tsx`).
+6. Add the "You'll receive back" summary row with a top divider.
+7. Handle loading state (spinner) and error fallback (generic text).
+8. Run frontend lint/typecheck; fix any issues.
+
+### Relevant Context
+- `booking_system_frontend/src/pages/MyBookings.tsx` lines 252-276 — current modal body to replace.
+- `booking_system_frontend/src/pages/MyBookings.tsx` lines 97-120 — `handleConfirmCancel` (no changes needed here).
+- `booking_system_frontend/src/utils/formatters.ts` lines 39-46 — `formatCurrency` for all amounts.
+- `booking_system_frontend/tailwind.config.js` — space-themed palette; use only tokens defined there.
+- `booking_system_frontend/src/components/bookings/BookingCard.tsx` — check icon imports already in use.
+- Issue #43 design notes specify tier badge, proportion bar, per-row icons, and summary row as required UI elements.

--- a/booking_system_backend/schemas.py
+++ b/booking_system_backend/schemas.py
@@ -85,3 +85,12 @@ class ErrorResponse(BaseModel):
     error: str
     error_code: str
     details: str | None = None
+
+
+class CancellationPreview(BaseModel):
+    tier_label: str
+    refund_amount: int
+    fee_amount: int
+    credit_amount: int
+    total_forfeited: int
+    price_paid: int

--- a/booking_system_backend/server.py
+++ b/booking_system_backend/server.py
@@ -12,6 +12,7 @@ from db import get_db, init_db
 from schemas import (
     BookingOut,
     BookingRequest,
+    CancellationPreview,
     ErrorResponse,
     FlightOut,
     UserOut,
@@ -166,6 +167,21 @@ def book_flight_endpoint(request: BookingRequest, db: Session = Depends(get_db))
     return result
 
 
+@app.get("/bookings/{id}/cancellation-preview", response_model=CancellationPreview, tags=["Bookings"])
+def get_cancellation_preview_endpoint(id: int, db: Session = Depends(get_db)):
+    """Return the cancellation-policy breakdown for a booking before confirming cancellation.
+
+    Returns tier label, refund amount, fee, travel credit, and net forfeited amount.
+    Raises 404 if the booking does not exist.
+    """
+    result = booking.get_cancellation_preview(db, id)
+    if isinstance(result, ErrorResponse):
+        raise HTTPException(status_code=404, detail=result.model_dump())
+    return result
+
+
+# NOTE: /bookings/{id}/cancellation-preview must be registered above this route —
+# FastAPI matches in registration order and this wildcard would shadow the two-segment path otherwise.
 @app.get("/bookings/{user_id}", response_model=list[BookingOut], tags=["Bookings"])
 def get_user_bookings(user_id: int, db: Session = Depends(get_db)):
     """Retrieve all bookings for a specific user by user_id."""

--- a/booking_system_backend/services/booking.py
+++ b/booking_system_backend/services/booking.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from sqlalchemy.orm import Session
 
 from models import Booking, Flight, User
-from schemas import BookingOut, ErrorResponse, SeatClass
+from schemas import BookingOut, CancellationPreview, ErrorResponse, SeatClass
 
 # Price multipliers for each seat class
 SEAT_CLASS_MULTIPLIERS = {
@@ -127,3 +127,88 @@ def get_bookings(db: Session, user_id: int) -> list[BookingOut]:
     """Retrieve all bookings for a specific user."""
     bookings = db.query(Booking).filter(Booking.user_id == user_id).all()
     return [BookingOut.model_validate(b) for b in bookings]
+
+
+# Supported departure_time string formats (seed data uses ISO-Z, test fixtures use "YYYY-MM-DD HH:MM")
+_DEPARTURE_TIME_FORMATS = [
+    "%Y-%m-%d %H:%M",
+    "%Y-%m-%dT%H:%M:%SZ",
+    "%Y-%m-%dT%H:%M:%S",
+]
+
+
+def compute_cancellation_preview(price_paid: int, departure_time: str) -> CancellationPreview:
+    """Compute the cancellation-policy breakdown for a booking.
+
+    Days-to-departure is calculated as timedelta.days (integer floor), matching the
+    policy tier table exactly.  Current time reference is datetime.utcnow() — a future
+    cleanup should switch to datetime.now(timezone.utc) once Python 3.12+ is required.
+
+    Policy tiers:
+      7+   days  → 100% cash refund, 0% fee, 0% credit
+      3–6  days  → 75% refund, 10% fee, 15% credit
+      1–2  days  → 0% refund, 25% fee, 25% credit
+      0    days  → 0% refund, 0% fee, 0% credit (total forfeit)
+
+    Raises ValueError for unrecognised departure_time formats.
+    """
+    parsed: datetime | None = None
+    for fmt in _DEPARTURE_TIME_FORMATS:
+        try:
+            parsed = datetime.strptime(departure_time, fmt)
+            break
+        except ValueError:
+            continue
+    if parsed is None:
+        raise ValueError(
+            f"Unrecognised departure_time format: {departure_time!r}. "
+            f"Expected one of: {_DEPARTURE_TIME_FORMATS}"
+        )
+
+    days_to_departure = (parsed - datetime.utcnow()).days  # integer floor via timedelta.days
+
+    if days_to_departure >= 7:
+        tier_label = "Full Refund"
+        refund_pct, fee_pct, credit_pct = 1.0, 0.0, 0.0
+    elif days_to_departure >= 3:
+        tier_label = "Partial Refund"
+        refund_pct, fee_pct, credit_pct = 0.75, 0.10, 0.15
+    elif days_to_departure >= 1:
+        tier_label = "Non-refundable"
+        refund_pct, fee_pct, credit_pct = 0.0, 0.25, 0.25
+    else:
+        tier_label = "Forfeit"
+        refund_pct, fee_pct, credit_pct = 0.0, 0.0, 0.0
+
+    refund_amount = int(price_paid * refund_pct)
+    fee_amount = int(price_paid * fee_pct)
+    credit_amount = int(price_paid * credit_pct)
+    total_forfeited = price_paid - refund_amount - credit_amount
+
+    return CancellationPreview(
+        tier_label=tier_label,
+        refund_amount=refund_amount,
+        fee_amount=fee_amount,
+        credit_amount=credit_amount,
+        total_forfeited=total_forfeited,
+        price_paid=price_paid,
+    )
+
+
+def get_cancellation_preview(db: Session, booking_id: int) -> CancellationPreview | ErrorResponse:
+    """Return a cancellation-policy preview for an existing booking."""
+    booking = db.query(Booking).filter(Booking.booking_id == booking_id).first()
+    if not booking:
+        return ErrorResponse(
+            error="Booking not found",
+            error_code="BOOKING_NOT_FOUND",
+            details=f"Booking with ID {booking_id} not found.",
+        )
+    flight = db.query(Flight).filter(Flight.flight_id == booking.flight_id).first()
+    if not flight:
+        return ErrorResponse(
+            error="Flight not found",
+            error_code="FLIGHT_NOT_FOUND",
+            details=f"Flight for booking {booking_id} could not be found.",
+        )
+    return compute_cancellation_preview(int(booking.price_paid), str(flight.departure_time))

--- a/booking_system_backend/tests/test_cancellation.py
+++ b/booking_system_backend/tests/test_cancellation.py
@@ -1,0 +1,174 @@
+"""Unit tests for compute_cancellation_preview and get_cancellation_preview."""
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from models import Booking, Flight, User
+from schemas import CancellationPreview, ErrorResponse
+from services.booking import compute_cancellation_preview, get_cancellation_preview
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _future_datetime_str(days: int, fmt: str = "%Y-%m-%d %H:%M") -> str:
+    """Return a departure_time string that is exactly *days* days from 'now'."""
+    # We freeze 'now' inside the call via mock, so the exact base doesn't matter —
+    # tests use a fixed reference.
+    dt = datetime(2099, 6, 15, 12, 0, 0) + timedelta(days=days)
+    return dt.strftime(fmt)
+
+
+# Fixed "now" used in all tier tests so results are deterministic.
+_NOW = datetime(2099, 6, 15, 0, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Tier tests — pure helper (no DB)
+# ---------------------------------------------------------------------------
+
+class TestComputeCancellationPreviewTiers:
+    """Test all four policy tiers using a mocked utcnow."""
+
+    def _call(self, days: int, price_paid: int = 1000, fmt: str = "%Y-%m-%d %H:%M") -> CancellationPreview:
+        departure = (_NOW + timedelta(days=days)).strftime(fmt)
+        with patch("services.booking.datetime") as mock_dt:
+            mock_dt.strptime = datetime.strptime  # keep real strptime
+            mock_dt.utcnow.return_value = _NOW
+            return compute_cancellation_preview(price_paid, departure)
+
+    def test_tier_full_refund_exactly_7_days(self):
+        preview = self._call(days=7, price_paid=1000)
+        assert preview.tier_label == "Full Refund"
+        assert preview.refund_amount == 1000
+        assert preview.fee_amount == 0
+        assert preview.credit_amount == 0
+        assert preview.total_forfeited == 0
+        assert preview.price_paid == 1000
+
+    def test_tier_full_refund_more_than_7_days(self):
+        preview = self._call(days=30, price_paid=2000)
+        assert preview.tier_label == "Full Refund"
+        assert preview.refund_amount == 2000
+        assert preview.fee_amount == 0
+        assert preview.total_forfeited == 0
+
+    def test_tier_partial_refund_exactly_3_days(self):
+        preview = self._call(days=3, price_paid=1000)
+        assert preview.tier_label == "Partial Refund"
+        assert preview.refund_amount == 750  # 75%
+        assert preview.fee_amount == 100    # 10%
+        assert preview.credit_amount == 150  # 15%
+        assert preview.total_forfeited == 100  # price_paid - refund - credit
+        assert preview.price_paid == 1000
+
+    def test_tier_partial_refund_exactly_6_days(self):
+        preview = self._call(days=6, price_paid=1000)
+        assert preview.tier_label == "Partial Refund"
+        assert preview.refund_amount == 750
+
+    def test_tier_non_refundable_exactly_1_day(self):
+        preview = self._call(days=1, price_paid=1000)
+        assert preview.tier_label == "Non-refundable"
+        assert preview.refund_amount == 0
+        assert preview.fee_amount == 250   # 25%
+        assert preview.credit_amount == 250  # 25%
+        assert preview.total_forfeited == 750  # price_paid - refund(0) - credit(250) = 750
+        assert preview.price_paid == 1000
+
+    def test_tier_non_refundable_exactly_2_days(self):
+        preview = self._call(days=2, price_paid=1000)
+        assert preview.tier_label == "Non-refundable"
+        assert preview.refund_amount == 0
+
+    def test_tier_forfeit_same_day(self):
+        preview = self._call(days=0, price_paid=1000)
+        assert preview.tier_label == "Forfeit"
+        assert preview.refund_amount == 0
+        assert preview.fee_amount == 0
+        assert preview.credit_amount == 0
+        assert preview.total_forfeited == 1000
+        assert preview.price_paid == 1000
+
+    def test_tier_forfeit_past_departure(self):
+        # Negative days (already departed) → same-day or past → forfeit
+        preview = self._call(days=-3, price_paid=500)
+        assert preview.tier_label == "Forfeit"
+        assert preview.total_forfeited == 500
+
+
+# ---------------------------------------------------------------------------
+# Date format tests
+# ---------------------------------------------------------------------------
+
+class TestComputeCancellationPreviewDateFormats:
+    """Test that all three supported departure_time string formats are parsed."""
+
+    def _call_with_raw(self, departure_time: str, price_paid: int = 1000) -> CancellationPreview:
+        with patch("services.booking.datetime") as mock_dt:
+            mock_dt.strptime = datetime.strptime
+            mock_dt.utcnow.return_value = datetime(2099, 1, 1, 0, 0, 0)
+            return compute_cancellation_preview(price_paid, departure_time)
+
+    def test_format_space_separated(self):
+        """Test fixture format: "YYYY-MM-DD HH:MM" (from conftest.py sample_flight_data)."""
+        # 2099-01-15 is 14 days after 2099-01-01 → Full Refund
+        preview = self._call_with_raw("2099-01-15 09:00")
+        assert preview.tier_label == "Full Refund"
+
+    def test_format_iso_z(self):
+        """Seed data format: "YYYY-MM-DDTHH:MM:SSZ" (from seed.py)."""
+        # Taken verbatim from seed.py style
+        preview = self._call_with_raw("2099-01-15T09:00:00Z")
+        assert preview.tier_label == "Full Refund"
+
+    def test_format_iso_no_z(self):
+        """ISO format without Z suffix: "YYYY-MM-DDTHH:MM:SS"."""
+        preview = self._call_with_raw("2099-01-15T09:00:00")
+        assert preview.tier_label == "Full Refund"
+
+    def test_invalid_format_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unrecognised departure_time format"):
+            compute_cancellation_preview(1000, "01/15/2099 09:00")
+
+
+# ---------------------------------------------------------------------------
+# get_cancellation_preview — service wrapper (uses DB fixture)
+# ---------------------------------------------------------------------------
+
+class TestGetCancellationPreview:
+    def test_returns_preview_for_existing_booking(self, db_session):
+        user = User(name="Traveler", email="traveler@galaxium.test")
+        flight = Flight(
+            origin="Earth", destination="Mars",
+            departure_time="2099-06-22 10:00",
+            arrival_time="2099-06-22 18:00",
+            base_price=500000,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1,
+        )
+        db_session.add_all([user, flight])
+        db_session.flush()
+        b = Booking(
+            user_id=user.user_id, flight_id=flight.flight_id,
+            status="booked", booking_time="2099-06-01T10:00:00Z",
+            seat_class="economy", price_paid=500000,
+        )
+        db_session.add(b)
+        db_session.commit()
+
+        result = get_cancellation_preview(db_session, b.booking_id)
+        assert isinstance(result, CancellationPreview)
+        assert result.price_paid == 500000
+
+    def test_returns_error_for_missing_booking(self, db_session):
+        result = get_cancellation_preview(db_session, 99999)
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "BOOKING_NOT_FOUND"

--- a/booking_system_frontend/src/pages/MyBookings.tsx
+++ b/booking_system_frontend/src/pages/MyBookings.tsx
@@ -1,15 +1,16 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import type { Booking, Flight, StoredHold, ErrorResponse } from '../types';
+import type { Booking, Flight, StoredHold, ErrorResponse, CancellationPreview } from '../types';
 import { LoadingSpinner, Modal, Button } from '../components/common';
 import { BookingCard } from '../components/bookings/BookingCard';
 import { HoldCard } from '../components/bookings/HoldCard';
-import { getUserBookings, getFlights, cancelBooking, getHold, isErrorResponse } from '../services/api';
+import { getUserBookings, getFlights, cancelBooking, getHold, getCancellationPreview, isErrorResponse } from '../services/api';
 import { getStoredHolds, removeHold } from '../utils/holdStorage';
 import { useUser } from '../hooks/useUserContext';
-import { AlertCircle } from 'lucide-react';
+import { AlertCircle, ArrowDownLeft, XCircle, Ticket } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { motion } from 'framer-motion';
+import { formatCurrency } from '../utils/formatters';
 
 export const MyBookings = () => {
   const { user } = useUser();
@@ -21,6 +22,9 @@ export const MyBookings = () => {
   const [cancellingId, setCancellingId] = useState<number | null>(null);
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [bookingToCancel, setBookingToCancel] = useState<number | null>(null);
+  const [previewData, setPreviewData] = useState<CancellationPreview | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState(false);
 
   const loadHolds = useCallback(async () => {
     if (!user) return;
@@ -89,9 +93,24 @@ export const MyBookings = () => {
     loadData();
   }, [user, navigate, loadData]);
 
-  const handleCancelClick = (bookingId: number) => {
+  const handleCancelClick = async (bookingId: number) => {
     setBookingToCancel(bookingId);
+    setPreviewData(null);
+    setPreviewError(false);
+    setPreviewLoading(true);
     setShowCancelModal(true);
+    try {
+      const result = await getCancellationPreview(bookingId);
+      if (isErrorResponse(result)) {
+        setPreviewError(true);
+      } else {
+        setPreviewData(result);
+      }
+    } catch {
+      setPreviewError(true);
+    } finally {
+      setPreviewLoading(false);
+    }
   };
 
   const handleConfirmCancel = async () => {
@@ -257,10 +276,96 @@ export const MyBookings = () => {
         size="sm"
       >
         <div className="space-y-4">
-          <p className="text-star-white/70">
-            Are you sure you want to cancel this booking? This action cannot be undone.
-          </p>
-          <div className="flex gap-3">
+          {previewLoading ? (
+            <LoadingSpinner size="sm" text="Loading refund preview…" />
+          ) : previewError || !previewData ? (
+            <p className="text-star-white/70">
+              Are you sure you want to cancel this booking? This action cannot be undone.
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {/* Tier badge */}
+              <div className="flex items-center gap-2">
+                <span className={`text-xs font-semibold px-2 py-1 rounded-full border ${
+                  previewData.tier_label === 'Full Refund'
+                    ? 'text-alien-green border-alien-green/40 bg-alien-green/10'
+                    : previewData.tier_label === 'Partial Refund'
+                    ? 'text-solar-orange border-solar-orange/40 bg-solar-orange/10'
+                    : previewData.tier_label === 'Non-refundable'
+                    ? 'text-nebula-pink border-nebula-pink/40 bg-nebula-pink/10'
+                    : 'text-star-white/50 border-white/20 bg-white/5'
+                }`}>
+                  {previewData.tier_label}
+                </span>
+                <span className="text-xs text-star-white/50">cancellation policy</span>
+              </div>
+
+              {/* Proportion bar */}
+              {previewData.price_paid > 0 && (
+                <div className="h-2 w-full rounded-full overflow-hidden flex bg-white/10">
+                  {previewData.refund_amount > 0 && (
+                    <div
+                      className="bg-alien-green h-full"
+                      style={{ width: `${(previewData.refund_amount / previewData.price_paid) * 100}%` }}
+                    />
+                  )}
+                  {previewData.credit_amount > 0 && (
+                    <div
+                      className="bg-solar-orange h-full"
+                      style={{ width: `${(previewData.credit_amount / previewData.price_paid) * 100}%` }}
+                    />
+                  )}
+                  {previewData.fee_amount > 0 && (
+                    <div
+                      className="bg-nebula-pink h-full"
+                      style={{ width: `${(previewData.fee_amount / previewData.price_paid) * 100}%` }}
+                    />
+                  )}
+                </div>
+              )}
+
+              {/* Per-row breakdown */}
+              <div className="space-y-2 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="flex items-center gap-2 text-alien-green">
+                    <ArrowDownLeft size={14} />
+                    Cash refund
+                  </span>
+                  <span className="text-star-white font-medium">
+                    {formatCurrency(previewData.refund_amount)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="flex items-center gap-2 text-solar-orange">
+                    <Ticket size={14} />
+                    Travel credit
+                  </span>
+                  <span className="text-star-white font-medium">
+                    {formatCurrency(previewData.credit_amount)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="flex items-center gap-2 text-nebula-pink">
+                    <XCircle size={14} />
+                    Cancellation fee
+                  </span>
+                  <span className="text-star-white font-medium">
+                    {formatCurrency(previewData.fee_amount)}
+                  </span>
+                </div>
+              </div>
+
+              {/* Net summary */}
+              <div className="pt-3 border-t border-white/10 flex items-center justify-between">
+                <span className="text-sm text-star-white/70">You'll receive back</span>
+                <span className="text-lg font-bold text-alien-green">
+                  {formatCurrency(previewData.refund_amount)}
+                </span>
+              </div>
+            </div>
+          )}
+
+          <div className="flex gap-3 pt-1">
             <Button
               variant="secondary"
               onClick={() => setShowCancelModal(false)}

--- a/booking_system_frontend/src/services/api.ts
+++ b/booking_system_frontend/src/services/api.ts
@@ -8,6 +8,7 @@ import type {
   ErrorResponse,
   Quote,
   Hold,
+  CancellationPreview,
 } from '../types';
 
 // Create axios instance with base configuration
@@ -142,6 +143,18 @@ export const cancelBooking = async (
 ): Promise<Booking | ErrorResponse> => {
   const response = await api.post<Booking | ErrorResponse>(
     `/cancel/${bookingId}`
+  );
+  return response.data;
+};
+
+/**
+ * Get the cancellation-policy preview for a booking before confirming cancellation
+ */
+export const getCancellationPreview = async (
+  bookingId: number
+): Promise<CancellationPreview | ErrorResponse> => {
+  const response = await api.get<CancellationPreview | ErrorResponse>(
+    `/bookings/${bookingId}/cancellation-preview`
   );
   return response.data;
 };

--- a/booking_system_frontend/src/types/index.ts
+++ b/booking_system_frontend/src/types/index.ts
@@ -113,4 +113,13 @@ export interface StoredHold {
   reservedUntil: string;
 }
 
+export interface CancellationPreview {
+  tier_label: string;
+  refund_amount: number;
+  fee_amount: number;
+  credit_amount: number;
+  total_forfeited: number;
+  price_paid: number;
+}
+
 // Made with Bob


### PR DESCRIPTION
# Summary

Adds a cancellation preview feature that shows users a detailed refund breakdown before they confirm a booking cancellation. This includes a new backend API endpoint with tiered cancellation policy logic, a corresponding frontend modal UI with a visual proportion bar and per-line breakdown, and full unit test coverage for the new service logic.

# Files Changed

📄 `.bob/custom_modes.yaml`

Uncomments the full `customModes` configuration, activating the `code-reviewer` and `deploy-engineer` custom AI modes that were previously commented out. No logic changes — purely a config activation.

📄 `booking_system_backend/schemas.py`

Adds a new `CancellationPreview` Pydantic model with fields for `tier_label`, `refund_amount`, `fee_amount`, `credit_amount`, `total_forfeited`, and `price_paid`. This schema is used as the response model for the new cancellation preview endpoint.

📄 `booking_system_backend/server.py`

Registers a new `GET /bookings/{id}/cancellation-preview` endpoint that returns the cancellation policy breakdown for a given booking before the user confirms cancellation. Includes a comment explaining that this route must be registered above the existing `GET /bookings/{user_id}` wildcard route to avoid FastAPI's registration-order shadowing.

📄 `booking_system_backend/services/booking.py`

Implements the core cancellation policy logic:
- `compute_cancellation_preview` — a pure function that parses a departure time string (supporting three formats), computes days-to-departure, applies the appropriate policy tier (Full Refund / Partial Refund / Non-refundable / Forfeit), and returns a populated `CancellationPreview`.
- `get_cancellation_preview` — a DB-aware wrapper that looks up the booking and its associated flight, then delegates to `compute_cancellation_preview`.

📄 `booking_system_backend/tests/test_cancellation.py`

New test file providing full unit test coverage for the cancellation preview logic, organised into three test classes:
- `TestComputeCancellationPreviewTiers` — verifies all four policy tiers and boundary days (0, 1, 2, 3, 6, 7, 30, and negative).
- `TestComputeCancellationPreviewDateFormats` — confirms all three supported `departure_time` string formats parse correctly, and that an unrecognised format raises `ValueError`.
- `TestGetCancellationPreview` — integration-style tests using a real DB session fixture, covering the happy path and the missing-booking error case.

📄 `booking_system_frontend/src/pages/MyBookings.tsx`

Updates the cancel booking modal to fetch and display a live cancellation preview before the user confirms. While the preview is loading, a spinner is shown. Once loaded, the modal renders a tier badge, a colour-coded proportion bar (green for refund, orange for travel credit, pink for fee), a per-line breakdown with icons, and a net "You'll receive back" summary. Falls back to the original plain confirmation message if the preview fetch fails.

📄 `booking_system_frontend/src/services/api.ts`

Adds the `getCancellationPreview` API function, which calls `GET /bookings/{bookingId}/cancellation-preview` and returns either a `CancellationPreview` or an `ErrorResponse`.

📄 `booking_system_frontend/src/types/index.ts`

Adds the `CancellationPreview` TypeScript interface, mirroring the backend Pydantic schema with fields for `tier_label`, `refund_amount`, `fee_amount`, `credit_amount`, `total_forfeited`, and `price_paid`.