### PR TITLE
feat: add refund preview feature

### DIFF
--- a/.bob/custom_modes.yaml
+++ b/.bob/custom_modes.yaml
@@ -1,47 +1,47 @@
-# customModes:
-#   - slug: code-reviewer
-#     name: Code Reviewer
-#     roleDefinition: >-
-#       You are a strict, read-only code reviewer. Your job is to read code and
-#       provide clear, actionable feedback on quality: naming conventions, code
-#       structure, consistency with project style, obvious bugs, dead code, and
-#       anything that would make the code harder to maintain or understand.
+customModes:
+  - slug: code-reviewer
+    name: Code Reviewer
+    roleDefinition: >-
+      You are a strict, read-only code reviewer. Your job is to read code and
+      provide clear, actionable feedback on quality: naming conventions, code
+      structure, consistency with project style, obvious bugs, dead code, and
+      anything that would make the code harder to maintain or understand.
 
-#       You never edit or create files. You never run the application. You may run
-#       linters and test suites to gather evidence, but only to inform your review.
+      You never edit or create files. You never run the application. You may run
+      linters and test suites to gather evidence, but only to inform your review.
 
-#       Your output is always a structured review: a short summary of findings,
-#       followed by specific issues with file references and line numbers where
-#       relevant. Distinguish between blocking issues (must fix) and suggestions
-#       (nice to have). Be direct and precise - do not pad feedback with praise.
-#     whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
-#     description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#   - slug: deploy-engineer
-#     name: Deploy Engineer
-#     roleDefinition: >-
-#       You are a Deploy Engineer. Your sole responsibility is making sure this
-#       project deploys correctly and reliably. You are an expert in the deployment
-#       scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
-#       infrastructure-as-code in this project.
+      Your output is always a structured review: a short summary of findings,
+      followed by specific issues with file references and line numbers where
+      relevant. Distinguish between blocking issues (must fix) and suggestions
+      (nice to have). Be direct and precise - do not pad feedback with praise.
+    whenToUse: Use when you want a read-only review of code quality, style, naming, and structure. Bob will not edit any files.
+    description: Read-only code quality reviewer. Audits style, naming, structure, and obvious bugs without modifying anything.
+    groups:
+      - read
+      - execute
+      - skill
+  - slug: deploy-engineer
+    name: Deploy Engineer
+    roleDefinition: >-
+      You are a Deploy Engineer. Your sole responsibility is making sure this
+      project deploys correctly and reliably. You are an expert in the deployment
+      scripts, CI/CD pipelines, Docker configuration, cloud provider CLIs, and
+      infrastructure-as-code in this project.
 
-#       You only read and edit files inside the scripts/ directory. You do not
-#       touch application source code, frontend assets, or test files. If a
-#       deployment problem traces back to application code, you report it clearly
-#       but do not fix it yourself.
+      You only read and edit files inside the scripts/ directory. You do not
+      touch application source code, frontend assets, or test files. If a
+      deployment problem traces back to application code, you report it clearly
+      but do not fix it yourself.
 
-#       When reviewing or editing deploy scripts, you check for: missing error
-#       handling, hardcoded secrets or environment assumptions, non-idempotent
-#       operations, missing health checks, and steps that could cause downtime.
-#       You run commands to validate and test deploy scripts where possible.
-#     whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
-#     description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
-#     groups:
-#       - read
-#       - execute
-#       - skill
-#       - - edit
-#         - fileRegex: "scripts/.*"
+      When reviewing or editing deploy scripts, you check for: missing error
+      handling, hardcoded secrets or environment assumptions, non-idempotent
+      operations, missing health checks, and steps that could cause downtime.
+      You run commands to validate and test deploy scripts where possible.
+    whenToUse: Use when working on deployment scripts, infrastructure config, or CI/CD pipelines. Scoped exclusively to the scripts/ directory.
+    description: Deployment-focused engineer scoped to the scripts/ directory. Reviews and edits deploy scripts, Docker config, and infrastructure code.
+    groups:
+      - read
+      - execute
+      - skill
+      - - edit
+        - fileRegex: "scripts/.*"

--- a/REFUND-PREVIEW-PLAN-REVIEWED.md
+++ b/REFUND-PREVIEW-PLAN-REVIEWED.md
@@ -1,0 +1,40 @@
+# Refund Preview on Cancel — Reviewed Plan
+
+**Status:** Draft · Reviewed  
+**Issue:** #43  
+**Branch:** `dev-day-demo-q3-2026-mj-10`
+
+---
+
+## Summary
+
+The refund-preview cancel modal replaces the generic "are you sure?" prompt with a rich breakdown showing tier badge, per-line-item amounts, and a proportion bar. The fee band in the proportion bar uses `nebula-pink` (the only warm/negative-signal colour in the custom Tailwind palette). Same-day (0%) cancellations skip the proportion bar and display a prominent "Non-refundable" warning banner instead. On preview fetch failure, the UI retries once after 2 seconds, then re-enables the Cancel button with plain fallback copy — users are never blocked indefinitely.
+
+---
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Fee band colour in proportion bar | `nebula-pink` (#EC4899) | No red token exists in the custom Tailwind palette; nebula-pink is the only warm/negative-signal colour available |
+| Same-day (0%) tier UX | Prominent "Non-refundable" banner + hide proportion bar | A zero-value bar conveys nothing; an explicit banner is the clearest UX signal |
+| Fallback when preview fetch fails | 2-second retry, then enable Cancel with plain fallback copy | Keeps the guard without blocking the user indefinitely if the endpoint is slow or unavailable |
+
+---
+
+## Open Items
+
+- The FastAPI route registration order is a critical footgun — the new `GET /bookings/{booking_id}/cancellation-preview` route **must** be inserted immediately above the existing `GET /bookings/{user_id}` route at [`server.py:169`](booking_system_backend/server.py:169)
+- `Ticket` icon availability in `lucide-react` should be verified before build; nearest equivalent (`Tag` or `Gift`) may be needed
+- The `formatCurrency` formatter should be confirmed to handle zero amounts gracefully (same-day tier)
+- No red Tailwind token — ensure nebula-pink reads as a "cost/negative" signal in the dark space theme to non-technical users
+
+---
+
+## Next Steps
+
+1. Implement Sub-Task 1: `CancellationPreviewOut` schema → `get_cancellation_preview` service function → REST endpoint inserted at the correct line in `server.py`
+2. Implement Sub-Task 2: unit tests covering all four tiers, both departure-time formats, 404, and 409 cases
+3. Implement Sub-Task 3: `CancellationPreview` TypeScript interface + `getCancellationPreview` API call in `api.ts`
+4. Implement Sub-Task 4: redesign cancel modal in `MyBookings.tsx` with tier badge, line items, proportion bar (`nebula-pink` for fee band), "Non-refundable" banner for same-day tier, and 2-second retry fallback
+5. Run `pytest booking_system_backend/tests/` and `npm run lint` to confirm no regressions before opening PR

--- a/REFUND-PREVIEW-PLAN.md
+++ b/REFUND-PREVIEW-PLAN.md
@@ -1,0 +1,153 @@
+# Refund Preview on Cancel — Implementation Plan
+
+**Issue:** #43  
+**Branch:** `dev-day-demo-q3-2026-mj-10`
+
+## Overview
+
+Replace the current "are you sure?" cancel modal with a rich refund-preview UI that shows the user exactly what they'll get back before confirming cancellation.
+
+The policy tiers are:
+
+| Days to departure | Cash refund | Fee | Travel credit |
+| -------------------| -------------| -----| ---------------|
+| 7+ days           | 100%        | 0%  | 0%            |
+| 3–6 days          | 75%         | 10% | 15%           |
+| 1–2 days          | 0%          | 25% | 25%           |
+| Same-day (0)      | 0%          | 0%  | 0%            |
+
+### Scope
+- New backend service function `get_cancellation_preview` with policy logic
+- New `GET /bookings/{id}/cancellation-preview` REST endpoint (registered **before** the existing `GET /bookings/{user_id}` route)
+- New MCP tool (auto-generated via FastMCP from the FastAPI route)
+- New `CancellationPreview` Pydantic schema
+- Policy helper unit-tested in the backend
+- `getCancellationPreview` function added to `api.ts`
+- `CancellationPreview` TypeScript type added to `types/index.ts`
+- Cancel modal in `MyBookings.tsx` updated to fetch and display the breakdown
+- Visual design: policy tier badge, segmented proportion bar, per-row icons, net cash summary row
+
+### Out of scope
+Actual refund processing; payment system is a stub.
+
+---
+
+## Sub-Tasks
+
+### Sub-Task 1 — Backend: Policy logic + new schema + endpoint
+
+**Status:** [ ] pending
+
+**Intent**  
+Implement all backend-side work: the cancellation-policy helper, a new `CancellationPreviewOut` schema, the `get_cancellation_preview` service function, and the REST endpoint. Getting this right first lets the frontend sub-task work against a real contract.
+
+**Expected Outcomes**
+- `GET /bookings/{booking_id}/cancellation-preview` returns a JSON payload with `tier_label`, `refund_amount`, `fee_amount`, `credit_amount`, and `total_price`
+- The route is registered **before** `GET /bookings/{user_id}` in `server.py` (FastAPI registration-order footgun)
+- Departure-time parsing handles both `"%Y-%m-%d %H:%M"` (test fixtures) and `"%Y-%m-%dT%H:%M:%S"` / `"%Y-%m-%dT%H:%M:%SZ"` (live DB / seed data)
+- Returns 404 if the booking is not found, 409 if already cancelled
+- FastMCP auto-generates an MCP tool for the route at no extra cost
+
+**Todo List**
+1. Add `CancellationPreviewOut` Pydantic schema to `booking_system_backend/schemas.py` with fields: `booking_id`, `tier_label`, `days_to_departure`, `total_price`, `refund_amount`, `fee_amount`, `credit_amount`
+2. Add `get_cancellation_preview(db, booking_id)` to `booking_system_backend/services/booking.py`:
+   - Look up the booking; return `ErrorResponse` if not found or already cancelled
+   - Look up the associated flight to get `departure_time` and `price_paid`
+   - Parse `departure_time` trying each format in order: `%Y-%m-%dT%H:%M:%SZ`, `%Y-%m-%dT%H:%M:%S`, `%Y-%m-%d %H:%M`; raise `ValueError` if none match
+   - Compute `days_to_departure` as `(departure_dt.date() - today.date()).days` (use UTC today)
+   - Apply the policy table to produce `tier_label`, `refund_amount`, `fee_amount`, `credit_amount`
+   - Return a `CancellationPreviewOut`
+3. In `server.py`, insert `GET /bookings/{booking_id}/cancellation-preview` **immediately above** the existing `GET /bookings/{user_id}` route (around line 169). Import `CancellationPreviewOut` in the import block.
+
+**Relevant Context**
+- `booking_system_backend/schemas.py` — add new schema here
+- `booking_system_backend/services/booking.py` — follow the `BookingOut | ErrorResponse` return-type pattern used by `cancel_booking`
+- `booking_system_backend/server.py:169` — critical registration order; new route must appear before `GET /bookings/{user_id}`
+- `booking_system_backend/seed.py:38` — departure times use `"YYYY-MM-DDTHH:MM:SSZ"` in the live DB
+- `booking_system_backend/tests/conftest.py:77` — test fixtures use `"YYYY-MM-DD HH:MM"` format
+
+---
+
+### Sub-Task 2 — Backend: Unit tests for policy logic
+
+**Status:** [ ] pending
+
+**Intent**  
+Verify the policy helper and endpoint in isolation, covering all four policy tiers and both date-format variants. The acceptance criteria explicitly require unit tests for the policy helper.
+
+**Expected Outcomes**
+- At least one test per policy tier (7+, 3–6, 1–2, 0 days) verifying `refund_amount`, `fee_amount`, `credit_amount`, and `tier_label`
+- At least one test using the ISO-8601-with-Z format from `seed.py` (e.g. `"2099-01-01T09:00:00Z"`)
+- At least one test using the test-fixture format (`"2099-01-01 09:00"`)
+- 404 test for unknown `booking_id`
+- 409 test for already-cancelled booking
+- All existing tests continue to pass (`pytest booking_system_backend/tests/`)
+
+**Todo List**
+1. Add a new test class `TestCancellationPreview` to `booking_system_backend/tests/test_services.py`
+2. For each of the four tiers, create a booking with a flight whose `departure_time` puts it in the correct tier window relative to today; assert amounts and label
+3. Add one test using the `"YYYY-MM-DDTHH:MM:SSZ"` departure format (mirrors seed data)
+4. Add a 404 test (booking not found) and a 409 test (booking already cancelled)
+5. Optionally add REST-level tests in `test_rest.py` for the new endpoint following existing patterns
+
+**Relevant Context**
+- `booking_system_backend/tests/test_services.py:267` — `TestBookingService` for pattern reference
+- `booking_system_backend/tests/conftest.py` — `db_session` fixture; use `datetime.now(tz=timezone.utc) + timedelta(days=N)` to control departure distance
+- Policy math: price_paid × percentage rates; use integer arithmetic to match backend
+
+---
+
+### Sub-Task 3 — Frontend: TypeScript type + API call
+
+**Status:** [ ] pending
+
+**Intent**  
+Expose the new endpoint to the frontend by adding a matching TypeScript interface and an `api.ts` function, following existing conventions.
+
+**Expected Outcomes**
+- `CancellationPreview` interface exported from `booking_system_frontend/src/types/index.ts`
+- `getCancellationPreview(bookingId: number): Promise<CancellationPreview>` exported from `booking_system_frontend/src/services/api.ts`
+- Follows the existing pattern: axios call, inspect `success` / error fields per AGENTS.md conventions
+
+**Todo List**
+1. Add `CancellationPreview` interface to `booking_system_frontend/src/types/index.ts` mirroring the backend schema fields: `booking_id`, `tier_label`, `days_to_departure`, `total_price`, `refund_amount`, `fee_amount`, `credit_amount`
+2. Add `getCancellationPreview` async function to `booking_system_frontend/src/services/api.ts` calling `GET /bookings/{bookingId}/cancellation-preview`; import `CancellationPreview` type
+
+**Relevant Context**
+- `booking_system_frontend/src/services/api.ts:132` — `getUserBookings` is the nearest comparable GET-by-id pattern
+- `booking_system_frontend/src/types/index.ts` — add the new interface alongside `Booking`
+
+---
+
+### Sub-Task 4 — Frontend: Cancel modal redesign in MyBookings
+
+**Status:** [ ] pending
+
+**Intent**  
+Replace the plain "are you sure?" cancel modal with the rich refund-preview breakdown described in the issue design notes: a policy-tier badge at the top, a segmented proportion bar, per-row icons for refund/fee/credit, and a net "You'll receive back" summary row.
+
+**Expected Outcomes**
+- Opening the cancel modal triggers `getCancellationPreview` and shows a loading state
+- The modal displays: tier badge, three line items with icons and amounts, proportion bar, net summary row
+- The "Cancel Booking" confirm button is disabled while the preview is loading
+- If the preview fetch fails gracefully, the modal falls back to the original "are you sure?" copy so cancel still works
+- Wording reads like a real travel product, not a debug dump
+- No layout regressions on the rest of the `MyBookings` page
+
+**Todo List**
+1. Add state for `cancellationPreview` (`CancellationPreview | null`) and `previewLoading` (`boolean`) to `MyBookings.tsx`
+2. In `handleCancelClick`, after setting `bookingToCancel` and `showCancelModal`, call `getCancellationPreview(bookingId)` asynchronously and set the preview state
+3. Replace the modal body in `MyBookings.tsx` with a new layout:
+   - **Policy tier badge** — e.g. `"Full Refund ✓"`, `"Partial Refund"`, `"Non-refundable"` derived from `tier_label`
+   - **Three line items** with icons (`ArrowLeftCircle` for refund, `XCircle` for fee, `Ticket` for credit) showing label + formatted amount
+   - **Proportion bar** — a flex row of coloured bands (green for refund, red for fee, amber for credit); widths proportional to amounts; hidden when all amounts are zero
+   - **Divider + "You'll receive back" row** showing `refund_amount` in a larger font
+4. Reset `cancellationPreview` and `previewLoading` in `handleConfirmCancel` and in the modal's `onClose` handler
+5. Import `getCancellationPreview` and `CancellationPreview` at the top of `MyBookings.tsx`
+
+**Relevant Context**
+- `booking_system_frontend/src/pages/MyBookings.tsx:252–276` — current modal block to replace
+- `booking_system_frontend/src/components/common/Modal.tsx` — modal accepts `size="sm"|"md"|"lg"`; upgrade to `"md"` for the richer layout
+- `booking_system_frontend/tailwind.config.js` — use project tokens (`text-alien-green`, `text-solar-orange`, `text-cosmic-purple`, etc.) not standard Tailwind colour names
+- `booking_system_frontend/src/utils/formatters.ts` — use `formatCurrency` for amounts
+- Lucide icon names already imported in `BookingCard.tsx`: `XCircle`; add `ArrowLeftCircle` and `Ticket` (or nearest equivalents) from `lucide-react`

--- a/booking_system_backend/schemas.py
+++ b/booking_system_backend/schemas.py
@@ -81,7 +81,17 @@ class UserOut(BaseModel):
 
 
 class ErrorResponse(BaseModel):
-    success: bool = False
-    error: str
-    error_code: str
-    details: str | None = None
+  success: bool = False
+  error: str
+  error_code: str
+  details: str | None = None
+
+
+class CancellationPreviewOut(BaseModel):
+    booking_id: int
+    tier_label: str
+    days_to_departure: int
+    total_price: int
+    refund_amount: int
+    fee_amount: int
+    credit_amount: int

--- a/booking_system_backend/server.py
+++ b/booking_system_backend/server.py
@@ -12,6 +12,7 @@ from db import get_db, init_db
 from schemas import (
     BookingOut,
     BookingRequest,
+    CancellationPreviewOut,
     ErrorResponse,
     FlightOut,
     UserOut,
@@ -162,6 +163,21 @@ def book_flight_endpoint(request: BookingRequest, db: Session = Depends(get_db))
     result = booking.book_flight(db, request.user_id, request.name, request.flight_id, request.seat_class)
     if isinstance(result, ErrorResponse):
         status = 404 if result.error_code in ("FLIGHT_NOT_FOUND", "USER_NOT_FOUND") else 409
+        raise HTTPException(status_code=status, detail=result.model_dump())
+    return result
+
+
+@app.get("/bookings/{booking_id}/cancellation-preview", response_model=CancellationPreviewOut, tags=["Bookings"])
+def get_cancellation_preview(booking_id: int, db: Session = Depends(get_db)):
+    """Preview the refund breakdown for cancelling a booking.
+
+    Returns tier_label, days_to_departure, total_price, refund_amount, fee_amount,
+    and credit_amount without modifying the booking.
+    Raises 404 if booking is not found, 409 if already cancelled.
+    """
+    result = booking.get_cancellation_preview(db, booking_id)
+    if isinstance(result, ErrorResponse):
+        status = 404 if result.error_code == "BOOKING_NOT_FOUND" else 409
         raise HTTPException(status_code=status, detail=result.model_dump())
     return result
 

--- a/booking_system_backend/services/booking.py
+++ b/booking_system_backend/services/booking.py
@@ -3,7 +3,18 @@ from datetime import datetime, timezone
 from sqlalchemy.orm import Session
 
 from models import Booking, Flight, User
-from schemas import BookingOut, ErrorResponse, SeatClass
+from schemas import BookingOut, CancellationPreviewOut, ErrorResponse, SeatClass
+
+# Cancellation policy tiers
+# (min_days, max_days_inclusive, tier_label, refund_pct, fee_pct, credit_pct)
+_CANCELLATION_POLICY = [
+    (7,   None, "Full Refund",    100,  0,  0),
+    (3,   6,    "Partial Refund",  75, 10, 15),
+    (1,   2,    "Late Cancel",      0, 25, 25),
+    (0,   0,    "Non-refundable",   0,  0,  0),
+]
+
+_DEPARTURE_FORMATS = ["%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M"]
 
 # Price multipliers for each seat class
 SEAT_CLASS_MULTIPLIERS = {
@@ -127,3 +138,58 @@ def get_bookings(db: Session, user_id: int) -> list[BookingOut]:
     """Retrieve all bookings for a specific user."""
     bookings = db.query(Booking).filter(Booking.user_id == user_id).all()
     return [BookingOut.model_validate(b) for b in bookings]
+
+
+def get_cancellation_preview(db: Session, booking_id: int) -> CancellationPreviewOut | ErrorResponse:
+    """Return a refund breakdown for a booking without actually cancelling it."""
+    b = db.query(Booking).filter(Booking.booking_id == booking_id).first()
+    if not b:
+        return ErrorResponse(
+            error="Booking not found",
+            error_code="BOOKING_NOT_FOUND",
+            details=f"Booking with ID {booking_id} not found.",
+        )
+    if b.status == "cancelled":
+        return ErrorResponse(
+            error="Booking already cancelled",
+            error_code="ALREADY_CANCELLED",
+            details=f"Booking {booking_id} is already cancelled; no refund preview is available.",
+        )
+
+    flight = db.query(Flight).filter(Flight.flight_id == b.flight_id).first()
+
+    # Parse departure_time trying each known format
+    departure_dt = None
+    for fmt in _DEPARTURE_FORMATS:
+        try:
+            departure_dt = datetime.strptime(flight.departure_time, fmt)
+            break
+        except ValueError:
+            continue
+    if departure_dt is None:
+        raise ValueError(f"Unrecognised departure_time format: {flight.departure_time!r}")
+
+    today = datetime.now(tz=timezone.utc).date()
+    days_to_departure = (departure_dt.date() - today).days
+
+    # Find the matching policy tier
+    tier_label, refund_pct, fee_pct, credit_pct = "Non-refundable", 0, 0, 0
+    for min_days, max_days, label, r, f, c in _CANCELLATION_POLICY:
+        if days_to_departure >= min_days and (max_days is None or days_to_departure <= max_days):
+            tier_label, refund_pct, fee_pct, credit_pct = label, r, f, c
+            break
+
+    total = b.price_paid
+    refund_amount = int(total * refund_pct / 100)
+    fee_amount = int(total * fee_pct / 100)
+    credit_amount = int(total * credit_pct / 100)
+
+    return CancellationPreviewOut(
+        booking_id=booking_id,
+        tier_label=tier_label,
+        days_to_departure=days_to_departure,
+        total_price=total,
+        refund_amount=refund_amount,
+        fee_amount=fee_amount,
+        credit_amount=credit_amount,
+    )

--- a/booking_system_backend/tests/test_services.py
+++ b/booking_system_backend/tests/test_services.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -481,6 +482,104 @@ class TestBookingService:
         result = booking.get_bookings(db_session, 999)
         assert result == []
 
+
+class TestCancellationPreview:
+    """Test get_cancellation_preview service function."""
+
+    def _make_booking(self, db_session, days_ahead: int, departure_fmt: str = "%Y-%m-%d %H:%M", price: int = 1000000):
+        """Helper: create a user, flight and booked booking departing N days from today."""
+        dep = (datetime.now(tz=timezone.utc) + timedelta(days=days_ahead)).replace(
+            hour=12, minute=0, second=0, microsecond=0
+        )
+        dep_str = dep.strftime(departure_fmt)
+        db_session.add(User(name="Traveller", email="t@example.com"))
+        db_session.add(Flight(
+            origin="Earth",
+            destination="Mars",
+            departure_time=dep_str,
+            arrival_time=dep_str,
+            base_price=price,
+            economy_seats_available=5,
+            business_seats_available=3,
+            galaxium_seats_available=1
+        ))
+        db_session.commit()
+        user_obj = db_session.query(User).first()
+        flight_obj = db_session.query(Flight).first()
+        db_session.add(Booking(
+            user_id=user_obj.user_id,
+            flight_id=flight_obj.flight_id,
+            status="booked",
+            booking_time="2099-01-01 10:00",
+            seat_class="economy",
+            price_paid=price,
+        ))
+        db_session.commit()
+        return db_session.query(Booking).first()
+
+    # --- tier: 7+ days (Full Refund) ---
+    def test_tier_full_refund(self, db_session):
+        b = self._make_booking(db_session, days_ahead=10, price=1000000)
+        result = booking.get_cancellation_preview(db_session, b.booking_id)
+        assert result.tier_label == "Full Refund"
+        assert result.refund_amount == 1000000
+        assert result.fee_amount == 0
+        assert result.credit_amount == 0
+
+    # --- tier: 3–6 days (Partial Refund) ---
+    def test_tier_partial_refund(self, db_session):
+        b = self._make_booking(db_session, days_ahead=5, price=1000000)
+        result = booking.get_cancellation_preview(db_session, b.booking_id)
+        assert result.tier_label == "Partial Refund"
+        assert result.refund_amount == 750000   # 75%
+        assert result.fee_amount == 100000      # 10%
+        assert result.credit_amount == 150000   # 15%
+
+    # --- tier: 1–2 days (Late Cancel) ---
+    def test_tier_late_cancel(self, db_session):
+        b = self._make_booking(db_session, days_ahead=2, price=1000000)
+        result = booking.get_cancellation_preview(db_session, b.booking_id)
+        assert result.tier_label == "Late Cancel"
+        assert result.refund_amount == 0
+        assert result.fee_amount == 250000   # 25%
+        assert result.credit_amount == 250000  # 25%
+
+    # --- tier: 0 days (Non-refundable / same-day) ---
+    def test_tier_non_refundable(self, db_session):
+        b = self._make_booking(db_session, days_ahead=0, price=1000000)
+        result = booking.get_cancellation_preview(db_session, b.booking_id)
+        assert result.tier_label == "Non-refundable"
+        assert result.refund_amount == 0
+        assert result.fee_amount == 0
+        assert result.credit_amount == 0
+
+    # --- ISO-8601-with-Z departure format (mirrors seed.py) ---
+    def test_iso_z_format(self, db_session):
+        b = self._make_booking(db_session, days_ahead=10, departure_fmt="%Y-%m-%dT%H:%M:%SZ")
+        result = booking.get_cancellation_preview(db_session, b.booking_id)
+        assert result.tier_label == "Full Refund"
+
+    # --- 404: booking not found ---
+    def test_booking_not_found(self, db_session):
+        result = booking.get_cancellation_preview(db_session, 99999)
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "BOOKING_NOT_FOUND"
+
+    # --- 409: booking already cancelled ---
+    def test_already_cancelled(self, db_session):
+        b = self._make_booking(db_session, days_ahead=10)
+        b.status = "cancelled"
+        db_session.commit()
+        result = booking.get_cancellation_preview(db_session, b.booking_id)
+        assert isinstance(result, ErrorResponse)
+        assert result.error_code == "ALREADY_CANCELLED"
+
+    # --- preview metadata is returned correctly ---
+    def test_returns_booking_id_and_total_price(self, db_session):
+        b = self._make_booking(db_session, days_ahead=10, price=500000)
+        result = booking.get_cancellation_preview(db_session, b.booking_id)
+        assert result.booking_id == b.booking_id
+        assert result.total_price == 500000
 
 
 class TestFlightFiltering:

--- a/booking_system_frontend/src/pages/MyBookings.tsx
+++ b/booking_system_frontend/src/pages/MyBookings.tsx
@@ -1,15 +1,16 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import type { Booking, Flight, StoredHold, ErrorResponse } from '../types';
+import type { Booking, Flight, StoredHold, ErrorResponse, CancellationPreview } from '../types';
 import { LoadingSpinner, Modal, Button } from '../components/common';
 import { BookingCard } from '../components/bookings/BookingCard';
 import { HoldCard } from '../components/bookings/HoldCard';
-import { getUserBookings, getFlights, cancelBooking, getHold, isErrorResponse } from '../services/api';
+import { getUserBookings, getFlights, cancelBooking, getHold, isErrorResponse, getCancellationPreview } from '../services/api';
 import { getStoredHolds, removeHold } from '../utils/holdStorage';
 import { useUser } from '../hooks/useUserContext';
-import { AlertCircle } from 'lucide-react';
+import { AlertCircle, ArrowLeftCircle, XCircle, Ticket } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { motion } from 'framer-motion';
+import { formatCurrency } from '../utils/formatters';
 
 export const MyBookings = () => {
   const { user } = useUser();
@@ -21,6 +22,8 @@ export const MyBookings = () => {
   const [cancellingId, setCancellingId] = useState<number | null>(null);
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [bookingToCancel, setBookingToCancel] = useState<number | null>(null);
+  const [cancellationPreview, setCancellationPreview] = useState<CancellationPreview | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
 
   const loadHolds = useCallback(async () => {
     if (!user) return;
@@ -91,7 +94,27 @@ export const MyBookings = () => {
 
   const handleCancelClick = (bookingId: number) => {
     setBookingToCancel(bookingId);
+    setCancellationPreview(null);
     setShowCancelModal(true);
+    setPreviewLoading(true);
+
+    let retried = false;
+    const fetchPreview = () => {
+      getCancellationPreview(bookingId)
+        .then((preview) => {
+          setCancellationPreview(preview);
+          setPreviewLoading(false);
+        })
+        .catch(() => {
+          if (!retried) {
+            retried = true;
+            setTimeout(fetchPreview, 2000);
+          } else {
+            setPreviewLoading(false);
+          }
+        });
+    };
+    fetchPreview();
   };
 
   const handleConfirmCancel = async () => {
@@ -99,6 +122,8 @@ export const MyBookings = () => {
 
     setCancellingId(bookingToCancel);
     setShowCancelModal(false);
+    setCancellationPreview(null);
+    setPreviewLoading(false);
 
     try {
       const result = await cancelBooking(bookingToCancel);
@@ -252,23 +277,146 @@ export const MyBookings = () => {
       {/* Cancel Confirmation Modal */}
       <Modal
         isOpen={showCancelModal}
-        onClose={() => setShowCancelModal(false)}
+        onClose={() => {
+          setShowCancelModal(false);
+          setCancellationPreview(null);
+          setPreviewLoading(false);
+        }}
         title="Cancel Booking"
-        size="sm"
+        size="md"
       >
-        <div className="space-y-4">
-          <p className="text-star-white/70">
-            Are you sure you want to cancel this booking? This action cannot be undone.
-          </p>
-          <div className="flex gap-3">
+        <div className="space-y-5">
+          {previewLoading && (
+            <div className="flex items-center justify-center py-6">
+              <LoadingSpinner size="sm" text="Calculating your refund…" />
+            </div>
+          )}
+
+          {!previewLoading && cancellationPreview && (
+            <>
+              {/* Tier badge */}
+              <div className="flex items-center gap-2">
+                {cancellationPreview.tier_label === 'Non-refundable' ? (
+                  <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-semibold bg-nebula-pink/20 text-nebula-pink border border-nebula-pink/40">
+                    <XCircle size={14} />
+                    {cancellationPreview.tier_label}
+                  </span>
+                ) : cancellationPreview.tier_label === 'Full Refund' ? (
+                  <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-semibold bg-alien-green/20 text-alien-green border border-alien-green/40">
+                    <ArrowLeftCircle size={14} />
+                    {cancellationPreview.tier_label}
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-semibold bg-solar-orange/20 text-solar-orange border border-solar-orange/40">
+                    <ArrowLeftCircle size={14} />
+                    {cancellationPreview.tier_label}
+                  </span>
+                )}
+                <span className="text-star-white/50 text-sm">
+                  {cancellationPreview.days_to_departure === 0
+                    ? 'Departing today'
+                    : `${cancellationPreview.days_to_departure} day${cancellationPreview.days_to_departure === 1 ? '' : 's'} to departure`}
+                </span>
+              </div>
+
+              {/* Same-day non-refundable banner */}
+              {cancellationPreview.tier_label === 'Non-refundable' && (
+                <div className="flex items-center gap-2 p-3 rounded-lg bg-nebula-pink/10 border border-nebula-pink/30 text-nebula-pink text-sm">
+                  <XCircle size={16} className="shrink-0" />
+                  <span>This booking is <strong>non-refundable</strong>. No cash or credit will be returned.</span>
+                </div>
+              )}
+
+              {/* Line items */}
+              <div className="rounded-lg border border-star-white/10 divide-y divide-star-white/10">
+                <div className="flex items-center justify-between px-4 py-3">
+                  <div className="flex items-center gap-2 text-star-white/70 text-sm">
+                    <ArrowLeftCircle size={15} className="text-alien-green" />
+                    Cash refund
+                  </div>
+                  <span className="text-star-white font-medium text-sm">
+                    {formatCurrency(cancellationPreview.refund_amount)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between px-4 py-3">
+                  <div className="flex items-center gap-2 text-star-white/70 text-sm">
+                    <XCircle size={15} className="text-nebula-pink" />
+                    Cancellation fee
+                  </div>
+                  <span className="text-nebula-pink font-medium text-sm">
+                    -{formatCurrency(cancellationPreview.fee_amount)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between px-4 py-3">
+                  <div className="flex items-center gap-2 text-star-white/70 text-sm">
+                    <Ticket size={15} className="text-solar-orange" />
+                    Travel credit
+                  </div>
+                  <span className="text-solar-orange font-medium text-sm">
+                    {formatCurrency(cancellationPreview.credit_amount)}
+                  </span>
+                </div>
+              </div>
+
+              {/* Proportion bar (hidden when all zero) */}
+              {(cancellationPreview.refund_amount > 0 || cancellationPreview.fee_amount > 0 || cancellationPreview.credit_amount > 0) && (
+                <div className="flex h-2 rounded-full overflow-hidden gap-px">
+                  {cancellationPreview.refund_amount > 0 && (
+                    <div
+                      className="bg-alien-green"
+                      style={{ flex: cancellationPreview.refund_amount }}
+                    />
+                  )}
+                  {cancellationPreview.fee_amount > 0 && (
+                    <div
+                      className="bg-nebula-pink"
+                      style={{ flex: cancellationPreview.fee_amount }}
+                    />
+                  )}
+                  {cancellationPreview.credit_amount > 0 && (
+                    <div
+                      className="bg-solar-orange"
+                      style={{ flex: cancellationPreview.credit_amount }}
+                    />
+                  )}
+                </div>
+              )}
+
+              {/* Net summary */}
+              <div className="flex items-center justify-between pt-1 border-t border-star-white/10">
+                <span className="text-star-white/70 text-sm">You'll receive back</span>
+                <span className="text-star-white font-bold text-lg">
+                  {formatCurrency(cancellationPreview.refund_amount)}
+                </span>
+              </div>
+            </>
+          )}
+
+          {/* Fallback copy when preview failed to load */}
+          {!previewLoading && !cancellationPreview && (
+            <p className="text-star-white/70 text-sm">
+              Are you sure you want to cancel this booking? This action cannot be undone.
+            </p>
+          )}
+
+          <div className="flex gap-3 pt-1">
             <Button
               variant="secondary"
-              onClick={() => setShowCancelModal(false)}
+              onClick={() => {
+                setShowCancelModal(false);
+                setCancellationPreview(null);
+                setPreviewLoading(false);
+              }}
               className="flex-1"
             >
               Keep Booking
             </Button>
-            <Button variant="danger" onClick={handleConfirmCancel} className="flex-1">
+            <Button
+              variant="danger"
+              onClick={handleConfirmCancel}
+              className="flex-1"
+              disabled={previewLoading}
+            >
               Cancel Booking
             </Button>
           </div>

--- a/booking_system_frontend/src/services/api.ts
+++ b/booking_system_frontend/src/services/api.ts
@@ -8,6 +8,7 @@ import type {
   ErrorResponse,
   Quote,
   Hold,
+  CancellationPreview,
 } from '../types';
 
 // Create axios instance with base configuration
@@ -143,6 +144,14 @@ export const cancelBooking = async (
   const response = await api.post<Booking | ErrorResponse>(
     `/cancel/${bookingId}`
   );
+  return response.data;
+};
+
+/**
+ * Preview refund breakdown for cancelling a booking (does not cancel)
+ */
+export const getCancellationPreview = async (bookingId: number): Promise<CancellationPreview> => {
+  const response = await api.get<CancellationPreview>(`/bookings/${bookingId}/cancellation-preview`);
   return response.data;
 };
 

--- a/booking_system_frontend/src/types/index.ts
+++ b/booking_system_frontend/src/types/index.ts
@@ -113,4 +113,14 @@ export interface StoredHold {
   reservedUntil: string;
 }
 
+export interface CancellationPreview {
+  booking_id: number;
+  tier_label: string;
+  days_to_departure: number;
+  total_price: number;
+  refund_amount: number;
+  fee_amount: number;
+  credit_amount: number;
+}
+
 // Made with Bob


### PR DESCRIPTION
# Summary

Adds a cancellation preview feature that allows users to see a detailed refund breakdown before confirming a booking cancellation. This includes a new backend endpoint with a tiered cancellation policy, a corresponding frontend modal UI that displays the refund tier, line-item breakdown, and a proportional visual bar, as well as full test coverage for the new service logic.

# Files Changed

📄 `.bob/custom_modes.yaml`

Uncomments the entire `customModes` configuration block, activating two custom AI modes — `code-reviewer` (a read-only code quality auditor) and `deploy-engineer` (a deployment-scoped engineer restricted to the `scripts/` directory).

📄 `booking_system_backend/schemas.py`

Adds a new `CancellationPreviewOut` Pydantic response model with fields for `booking_id`, `tier_label`, `days_to_departure`, `total_price`, `refund_amount`, `fee_amount`, and `credit_amount`. Also fixes indentation on the existing `ErrorResponse` model.

📄 `booking_system_backend/server.py`

Imports `CancellationPreviewOut` and registers a new `GET /bookings/{booking_id}/cancellation-preview` endpoint. The endpoint delegates to the booking service and maps `BOOKING_NOT_FOUND` to a 404 and `ALREADY_CANCELLED` to a 409.

📄 `booking_system_backend/services/booking.py`

Implements the `get_cancellation_preview` service function. Defines a `_CANCELLATION_POLICY` table of four tiers (Full Refund, Partial Refund, Late Cancel, Non-refundable) keyed by days to departure, supports multiple departure time string formats via `_DEPARTURE_FORMATS`, and returns a populated `CancellationPreviewOut` or an `ErrorResponse` for not-found or already-cancelled bookings.

📄 `booking_system_backend/tests/test_services.py`

Adds a `TestCancellationPreview` test class with a `_make_booking` helper and nine test cases covering: all four cancellation policy tiers, the ISO-8601-with-Z departure format, booking not found (404), already cancelled (409), and correct metadata (booking ID and total price) in the response.

📄 `booking_system_frontend/src/pages/MyBookings.tsx`

Extends the cancel booking flow to fetch and display a cancellation preview when the cancel modal opens. Shows a loading spinner while the preview is fetching, then renders a tier badge, days-to-departure label, line-item breakdown (cash refund, cancellation fee, travel credit), a proportional colour-coded bar, and a net refund summary. Falls back to a plain confirmation message if the preview fails to load after one retry. The confirm button is disabled while the preview is loading.

📄 `booking_system_frontend/src/services/api.ts`

Adds the `getCancellationPreview` API function, which issues a `GET` request to `/bookings/{bookingId}/cancellation-preview` and returns a typed `CancellationPreview` response.

📄 `booking_system_frontend/src/types/index.ts`

Defines the new `CancellationPreview` TypeScript interface with fields mirroring the backend response schema: `booking_id`, `tier_label`, `days_to_departure`, `total_price`, `refund_amount`, `fee_amount`, and `credit_amount`.